### PR TITLE
Filtering in getRecentAuditByType. Closes #243

### DIFF
--- a/src/APIv2/Controller.php
+++ b/src/APIv2/Controller.php
@@ -770,8 +770,13 @@ class Controller implements RequestHandlerInterface
 
 		$type = Validation::validateHasString($parameters, 'type');
 		$limit = Validation::validateOptionalInt($parameters, 'howMany', 100);
+		$featureFilter = Validation::validateOptionalString($parameters, 'featureFilter', null, null);
+		if ($featureFilter !== null) {
+			$exp = Validation::explodeFeatureValuePair($featureFilter);
+			$featureFilter = new Feature($exp[0], $exp[1]);
+		}
 
-		$data = $db->AuditDAO()->getRecentAuditByType($type, $limit);
+		$data = $db->AuditDAO()->getRecentAuditByType($type, $limit, $featureFilter);
 
 		return new JsonResponse($data);
 	}
@@ -875,7 +880,7 @@ class Controller implements RequestHandlerInterface
 
 		// this is disabled because it can actually be useful to have the list as soon as you start typing,
 		// still gonna leave this here in case anyone wants to change it
-		/*$min = 3; 
+		/*$min = 3;
 		if (strlen($search) < $min) {
 			throw new RangeException('q', $min, null, "Minimum length for autocomplete is $min");
 		}*/

--- a/src/APIv2/Routes.php
+++ b/src/APIv2/Routes.php
@@ -113,7 +113,7 @@ trait Routes
 							function (FastRoute\RouteCollector $r) {
 								$r->get('/getItemsForEachValue/{feature}[/{filter}[/{location}[/{creation}[/{deleted}]]]]', [User::AUTH_LEVEL_RO, [Controller::class, 'itemsByValue']]);
 								$r->get('/getItemByNotFeature/{filter}[/{notFeature}[/{location}[/{limit}[/{creation}[/{deleted}]]]]]', [User::AUTH_LEVEL_RO, [Controller::class, 'itemsNotFeature']]);
-								$r->get('/getRecentAuditByType/{type}[/{howMany}]', [User::AUTH_LEVEL_RO, [Controller::class, 'recentAuditByType']]);
+								$r->get('/getRecentAuditByType/{type}[/{howMany}[/{featureFilter}]]', [User::AUTH_LEVEL_RO, [Controller::class, 'recentAuditByType']]);
 								$r->get('/getCountByFeature/{feature}[/{filter}[/{location}[/{creation[/{deleted[/{cutoff}]]]]]', [User::AUTH_LEVEL_RO, [Controller::class, 'countByFeature']]);
 							}
 						);


### PR DESCRIPTION
I went for `v2/stats/getRecentAuditByType/U/5/<feature>=<value>` instead of the requested `v2/stats/getRecentAuditByType/U/5/<value>` mostly because filtering on the feature is also free.

So recent audits related to cases would be `v2/stats/getRecentAuditByType/U/5/type=case`.

There should be no performance regression on the unfiltered case and the filtered query doesn't seem to have an outrageous execution plan in MariaDB 10.4

Q: I've noticed the API shies away from using query parameters (URIs don't really identify resources either so it's not very usual). Is there a reason for that? Something along the lines of `v2/stats/getRecentAudits?type=<auditType>&filter=<feature>:<value>&limit=<limit>` would feel more natural, at least to me.