### PR TITLE
Split summarizer output on (.*) aswell. Close #162

### DIFF
--- a/src/SSRv1/templates/item.php
+++ b/src/SSRv1/templates/item.php
@@ -48,8 +48,12 @@ if (isset($edit)) {
 	}
 }
 
+// A little more logic in a template won't kill, right?
 $summary = \WEEEOpen\Tarallo\SSRv1\Summary\Summary::peel($item);
-$summary_escaped = array_map([$this, 'e'], explode(', ', $summary));
+$summary_split = preg_split("/(\(.*\))/", $summary, -1, PREG_SPLIT_DELIM_CAPTURE);
+$summary_split = array_map(fn($v): array => str_starts_with($v, '(') ? [$v] : explode(', ', $v), $summary_split);
+$flat = call_user_func_array('array_merge', $summary_split);
+$summary_escaped = array_map([$this, 'e'], $flat);
 unset($summary);
 
 $product = $item->getProduct();


### PR DESCRIPTION
One last for the night. I think it's sane, though I did not test it with anything except a PSU. Anything within parenthesis should now be ignored before splitting by `, `.

![new look](https://user-images.githubusercontent.com/490500/203634048-0fc01159-a623-4c8a-8636-836b1f4f49c6.png)
