### PR TITLE
Item rename API

### DIFF
--- a/sql/database-procedures.sql
+++ b/sql/database-procedures.sql
@@ -61,12 +61,14 @@ CREATE TRIGGER ItemBMVInsert
 	ON ItemFeature
 	FOR EACH ROW
 	BEGIN
-		IF(NEW.Feature = 'brand') THEN
-			UPDATE Item SET Brand = NEW.ValueText WHERE Code = NEW.Code;
-		ELSEIF(NEW.Feature = 'model') THEN
-			UPDATE Item SET Model = NEW.ValueText WHERE Code = NEW.Code;
-		ELSEIF(NEW.Feature = 'variant') THEN
-			UPDATE Item SET Variant = NEW.ValueText WHERE Code = NEW.Code;
+		IF(NEW.Code = OLD.Code) THEN -- This prevents infinite loop on item rename
+			IF(NEW.Feature = 'brand') THEN
+				UPDATE Item SET Brand = NEW.ValueText WHERE Code = NEW.Code;
+			ELSEIF(NEW.Feature = 'model') THEN
+				UPDATE Item SET Model = NEW.ValueText WHERE Code = NEW.Code;
+			ELSEIF(NEW.Feature = 'variant') THEN
+				UPDATE Item SET Variant = NEW.ValueText WHERE Code = NEW.Code;
+			END IF;
 		END IF;
 	END $$
 DELIMITER ;
@@ -213,20 +215,23 @@ DROP TRIGGER IF EXISTS CascadeItemCodeUpdateForReal;
 DELIMITER $$
 CREATE TRIGGER CascadeItemCodeUpdateForReal
 	BEFORE UPDATE
-	ON Item
-	FOR EACH ROW
-	BEGIN
-		IF(NEW.Code <> OLD.Code) THEN
-			SET FOREIGN_KEY_CHECKS = 0;
-			UPDATE Tree
-			SET Ancestor=NEW.Code
-			WHERE Ancestor=OLD.Code;
-			UPDATE Tree
-			SET Descendant=NEW.Code
-			WHERE Descendant=OLD.Code;
-			SET FOREIGN_KEY_CHECKS = 1;
-		END IF;
-	END $$
+    ON Item
+    FOR EACH ROW
+    BEGIN
+        IF(NEW.Code <> OLD.Code) THEN
+            SET FOREIGN_KEY_CHECKS = 0;
+            UPDATE ItemFeature
+            SET Code=NEW.Code
+            WHERE Code=OLD.Code;
+            UPDATE Tree
+            SET Ancestor=NEW.Code
+            WHERE Ancestor=OLD.Code;
+            UPDATE Tree
+            SET Descendant=NEW.Code
+            WHERE Descendant=OLD.Code;
+            SET FOREIGN_KEY_CHECKS = 1;
+        END IF;
+    END $$
 DELIMITER ;
 
 -- Search ----------------------------------------------------------------------

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -355,5 +355,5 @@ SELECT Code,
 FROM ProductItemFeature;
 
 -- Do not combine these lines, they're parsed by update-db... WITH A REGEX!
-INSERT INTO `Configuration` (`Key`, `Value`) VALUES ('SchemaVersion', 21);
+INSERT INTO `Configuration` (`Key`, `Value`) VALUES ('SchemaVersion', 22);
 INSERT INTO `Configuration` (`Key`, `Value`) VALUES ('DataVersion', 31);

--- a/src/APIv2/Controller.php
+++ b/src/APIv2/Controller.php
@@ -375,6 +375,36 @@ class Controller implements RequestHandlerInterface
 		return $response;
 	}
 
+	public static function renameItem(ServerRequestInterface $request): ResponseInterface
+	{
+		/** @var Database $db */
+		$db = $request->getAttribute('Database');
+		$parameters = $request->getAttribute('parameters', []);
+		$payload = $request->getAttribute('ParsedBody', []);
+
+		$id = Validation::validateHasString($parameters, 'id');
+		$newName = Validation::validateHasString($payload, 'name');
+
+		try {
+			$id = new ItemCode($id);
+		} catch (ValidationException $e) {
+			throw new NotFoundException($id);
+		}
+
+		$db->itemDAO()->itemMustExist($id, true);
+		
+		$newItem = new ItemCode($newName);
+		$db->itemDAO()->itemMustNotExist($newItem, true);
+
+		try {
+			$db->itemDAO()->renameItem($id, $newName);
+		} catch (ValidationException $e) {
+			throw new InvalidParameterException('name', $newName, "New name $newName, not a valid name");
+		}
+
+		return new EmptyResponse(204);
+	}
+
 	public static function removeItem(ServerRequestInterface $request): ResponseInterface
 	{
 		/** @var Database $db */

--- a/src/APIv2/Controller.php
+++ b/src/APIv2/Controller.php
@@ -383,7 +383,7 @@ class Controller implements RequestHandlerInterface
 		$payload = $request->getAttribute('ParsedBody', []);
 
 		$id = Validation::validateHasString($parameters, 'id');
-		$newName = Validation::validateHasString($payload, 'name');
+		$newName = Validation::validateHasString($payload, 'code');
 
 		try {
 			$id = new ItemCode($id);
@@ -399,7 +399,7 @@ class Controller implements RequestHandlerInterface
 		try {
 			$db->itemDAO()->renameItem($id, $newName);
 		} catch (ValidationException $e) {
-			throw new InvalidParameterException('name', $newName, "New name $newName, not a valid name");
+			throw new InvalidParameterException('code', $newName, "New code $newName, not a valid code");
 		}
 
 		return new EmptyResponse(204);

--- a/src/APIv2/Routes.php
+++ b/src/APIv2/Routes.php
@@ -34,7 +34,7 @@ trait Routes
 										$r->put('', [User::AUTH_LEVEL_RW, [Controller::class, 'createItem']]);
 										$r->delete('', [User::AUTH_LEVEL_RW, [Controller::class, 'removeItem']]);
 
-										$r->put('/rename', [User::AUTH_LEVEL_RW, [Controller::class, 'renameItem']]);
+										$r->put('/code', [User::AUTH_LEVEL_RW, [Controller::class, 'renameItem']]);
 
 										// Useless
 										//$r->get('/parent',  [User::AUTH_LEVEL_RW, [Controller::class, 'getItemParent']]);

--- a/src/APIv2/Routes.php
+++ b/src/APIv2/Routes.php
@@ -34,6 +34,8 @@ trait Routes
 										$r->put('', [User::AUTH_LEVEL_RW, [Controller::class, 'createItem']]);
 										$r->delete('', [User::AUTH_LEVEL_RW, [Controller::class, 'removeItem']]);
 
+										$r->put('/rename', [User::AUTH_LEVEL_RW, [Controller::class, 'renameItem']]);
+
 										// Useless
 										//$r->get('/parent',  [User::AUTH_LEVEL_RW, [Controller::class, 'getItemParent']]);
 										$r->put('/parent', [User::AUTH_LEVEL_RW, [Controller::class, 'setItemParent']]);

--- a/src/Database/ItemDAO.php
+++ b/src/Database/ItemDAO.php
@@ -57,7 +57,32 @@ final class ItemDAO extends DAO
 			$this->addItem($childItem, $item);
 		}
 	}
+	
+	/**
+	 * Soft-delete an item (mark as deleted to make invisible, detach from tree)
+	 *
+	 * @param ItemWithCode $item
+	 * @param string $newCode
+	 *
+	 * @throws ValidationException if item contains other items (cannot be deleted)
+	 */
+	public function renameItem(ItemWithCode $item, string $newCode)
+	{
+		$this->itemMustExist($item);
+		$statement = $this->getPDO()->prepare('UPDATE Item SET Code=:cod WHERE `Code` = :old');
 
+		try {
+			$statement->bindValue(':cod', $item->getCode(), \PDO::PARAM_STR);
+			$statement->bindValue(':old', $newCode, \PDO::PARAM_STR);
+			$result = $statement->execute();
+			assert($result !== false, 'update item');
+		} catch (\PDOException $e) {
+			throw $e;
+		} finally {
+			$statement->closeCursor();
+		}
+	}
+	
 	/**
 	 * Soft-delete an item (mark as deleted to make invisible, detach from tree)
 	 *

--- a/src/Database/Updater.php
+++ b/src/Database/Updater.php
@@ -692,6 +692,30 @@ END;"
   COLLATE = utf8mb4_unicode_ci;'
 					);
 					break;
+					case 21:
+						$this->exec("DROP TRIGGER IF EXISTS CascadeItemCodeUpdateForReal");
+						$this->exec("
+CREATE TRIGGER CascadeItemCodeUpdateForReal
+BEFORE UPDATE
+ON Item
+FOR EACH ROW
+BEGIN
+	IF(NEW.Code <> OLD.Code) THEN
+		SET FOREIGN_KEY_CHECKS = 0;
+		UPDATE ItemFeature
+		SET Code=NEW.Code
+		WHERE Code=OLD.Code;
+		UPDATE Tree
+		SET Ancestor=NEW.Code
+		WHERE Ancestor=OLD.Code;
+		UPDATE Tree
+		SET Descendant=NEW.Code
+		WHERE Descendant=OLD.Code;
+		SET FOREIGN_KEY_CHECKS = 1;
+	END IF;
+END;"
+						);
+						break;
 				default:
 					throw new \RuntimeException('Schema version larger than maximum');
 			}

--- a/src/Database/Updater.php
+++ b/src/Database/Updater.php
@@ -715,6 +715,24 @@ BEGIN
 	END IF;
 END;"
 						);
+						$this->exec("DROP TRIGGER IF EXISTS ItemBMVInsert");
+						$this->exec("
+CREATE TRIGGER ItemBMVInsert
+AFTER INSERT
+ON ItemFeature
+FOR EACH ROW
+BEGIN
+	IF(NEW.Code = OLD.Code) THEN -- This prevents infinite loop on item rename
+		IF(NEW.Feature = 'brand') THEN
+			UPDATE Item SET Brand = NEW.ValueText WHERE Code = NEW.Code;
+		ELSEIF(NEW.Feature = 'model') THEN
+			UPDATE Item SET Model = NEW.ValueText WHERE Code = NEW.Code;
+		ELSEIF(NEW.Feature = 'variant') THEN
+			UPDATE Item SET Variant = NEW.ValueText WHERE Code = NEW.Code;
+		END IF;
+	END IF;
+END
+						");
 						break;
 				default:
 					throw new \RuntimeException('Schema version larger than maximum');

--- a/src/FoundException.php
+++ b/src/FoundException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace WEEEOpen\Tarallo;
+
+use Throwable;
+
+class FoundException extends \RuntimeException
+{
+	use ExceptionWithItem;
+
+	public $status = 404;
+
+	public function __construct(?string $item = null, $message = null, $code = 0, Throwable $previous = null)
+	{
+		if ($item === null) {
+			parent::__construct($message ?? 'Item already exists', $code, $previous);
+		} else {
+			parent::__construct($message ?? "Item $item already exist", $code, $previous);
+			$this->item = $item;
+		}
+	}
+}

--- a/src/SSRv1/static/editor.js
+++ b/src/SSRv1/static/editor.js
@@ -155,6 +155,71 @@
 
 			enableFeatureHandlers(featuresElement, deletedFeatures);
 		}
+
+		// Item code edit button
+		$('.rename').on("click", function (ev) {
+			let dataset = ev.currentTarget.parentElement.parentElement.parentElement.dataset;
+			let currentCode = dataset.code;
+			swal({
+				title: "Input new item code:",
+				icon: "info",
+				buttons: {
+					cancel: {
+						text: "Cancel",
+						visible: true,
+
+					},
+					confirm: {
+						text: "Rename",
+						closeModal: false,
+					}
+				},
+				content: {
+					element: "input",
+					attributes: {
+						placeholder: "New Code", 
+						value: currentCode
+					}
+				}
+			}).then(async (value) => {
+				if (value == null || value == "") {
+					swal.close();
+				} else {
+					let response = await fetchWithTimeout('/v2/items/' + encodeURIComponent(currentCode) + '/code', {
+						headers: {
+							'Accept': 'application/json',
+							'Content-Type': 'application/json'
+						},
+						method: 'PUT',
+						credentials: 'include',
+						body: JSON.stringify({
+							"code":value
+						})
+					});
+					if (response.ok) {
+						swal({
+							icon: "success",
+							title: "Success",
+							text: "You will be redirected shortly"
+						});
+						setTimeout(()=>{
+							let pageCode = window.location.pathname.split('/')[2];
+							console.log(pageCode, currentCode);
+							if (pageCode == currentCode)
+								window.location.href = '/item/' + encodeURIComponent(value);
+							else 
+								window.location.href = '/item/' + encodeURIComponent(pageCode);
+						}, 2000);
+					} else {
+						swal({
+							icon: "error",
+							title: "Error",
+							text: await response.json().then(j => j.message)
+						});
+					}
+				}
+			});
+		});
 	}
 
 	/**

--- a/src/SSRv1/templates/editor.php
+++ b/src/SSRv1/templates/editor.php
@@ -37,4 +37,5 @@
 	<?php $this->insert('featuresList'); ?>
 </template>
 <!--suppress JSUnusedLocalSymbols -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/sweetalert/2.1.2/sweetalert.min.js" integrity="sha512-AA1Bzp5Q0K1KanKKmvN/4d3IRKVlv9PYgwFPvm32nPO6QS8yH1HO7LbgB1pgiOxPtfeg5zEn2ba64MUcqJx6CA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script src="/static/editor.js"></script>

--- a/src/SSRv1/templates/item.php
+++ b/src/SSRv1/templates/item.php
@@ -76,7 +76,7 @@ endif; ?>
 		<h4 class="p-2 col m-0" id="code-<?=$code_escaped?>"><?=$code_escaped?></h4>
 		<nav class="p-2 m-0 ml-auto itembuttons inheader">
 			<?php if ($editing) : ?>
-				<a class="btn btn-outline-secondary btn-sm btn-item disabled" role="button" href="#">
+				<a class="btn btn-outline-secondary btn-sm btn-item rename" role="button" href="#">
 					<i class="fa fa-pencil-alt"></i>&nbsp;Rename
 				</a>
 			<?php else : ?>


### PR DESCRIPTION
Closes #213 
Closes #216 

Fixed bug that prevented item rename, added interface in ItemDAO to rename items, added `itemMustNotExist` function, added API to rename item and added GUI in editor.
```http
PUT /v1/items/{id}/code

Body:
{
   "code":"newCode"
}
```
