### PR TITLE
Rework summarizer to output in tokens. Close #162

### DIFF
--- a/src/APIv2/Controller.php
+++ b/src/APIv2/Controller.php
@@ -696,10 +696,7 @@ class Controller implements RequestHandlerInterface
 		$db->itemDAO()->itemMustExist($item, true);
 
 		$itemWithFeatures = $db->itemDAO()->getItem($item);
-
-		$summary = Summary::peel($itemWithFeatures);
-
-		return new JsonResponse(["summary"=>$summary]);
+		return new JsonResponse(Summary::peel($itemWithFeatures));
   }
 
 	public static function itemsByValue(ServerRequestInterface $request): ResponseInterface

--- a/src/SSRv1/Summary/CaseSummarizer.php
+++ b/src/SSRv1/Summary/CaseSummarizer.php
@@ -7,7 +7,7 @@ use WEEEOpen\Tarallo\SSRv1\FeaturePrinter;
 
 class CaseSummarizer implements Summarizer
 {
-	public static function summarize(ItemWithFeatures $item): string
+	public static function summarize(ItemWithFeatures $item): array
 	{
 		$type = $item->getFeature('type');
 		$form = $item->getFeature('motherboard-form-factor');
@@ -17,15 +17,9 @@ class CaseSummarizer implements Summarizer
 		$type .= $form ? ' ' . FeaturePrinter::printableValue($form) : '';
 
 		$ports = PartialSummaries::summarizePorts($item, false);
-		$ports = $ports ? " ($ports)" : '';
-
-		$color = $color ? ', ' . FeaturePrinter::printableValue($color) : '';
-
+		$color = $color ? FeaturePrinter::printableValue($color) : '';
 		$commercial = PartialSummaries::summarizeCommercial($item);
-		$commercial = $commercial ? ", $commercial" : '';
 
-		$pretty = $type . $ports . $color . $commercial;
-
-		return $pretty;
+		return array_filter([$type, $ports, $color, $commercial]);
 	}
 }

--- a/src/SSRv1/Summary/GraphicCardSummarizer.php
+++ b/src/SSRv1/Summary/GraphicCardSummarizer.php
@@ -7,7 +7,7 @@ use WEEEOpen\Tarallo\SSRv1\FeaturePrinter;
 
 class GraphicCardSummarizer implements Summarizer
 {
-	public static function summarize(ItemWithFeatures $item): string
+	public static function summarize(ItemWithFeatures $item): array
 	{
 		$type = $item->getFeature('type');
 		$capacity = $item->getFeature('capacity-byte');
@@ -18,14 +18,12 @@ class GraphicCardSummarizer implements Summarizer
 		$type .= $socket ? " $socket" : '';
 		$type .= $capacity ? ' ' . FeaturePrinter::printableValue($capacity) : '';
 
-		$ports = PartialSummaries::summarizePorts($item, false, ' ');
-		$ports = $ports ? ", $ports" : '';
+		$ports = PartialSummaries::summarizePorts($item, false, ', ');
 
-		$color = $color ? ', ' . FeaturePrinter::printableValue($color) : '';
+		$color = $color ? FeaturePrinter::printableValue($color) : '';
 
 		$commercial = PartialSummaries::summarizeCommercial($item);
-		$commercial = $commercial ? ", $commercial" : '';
 
-		return $type . $ports . $color . $commercial;
+		return array_filter([$type, $ports, $color, $commercial]);
 	}
 }

--- a/src/SSRv1/Summary/HddSummarizer.php
+++ b/src/SSRv1/Summary/HddSummarizer.php
@@ -7,7 +7,7 @@ use WEEEOpen\Tarallo\SSRv1\FeaturePrinter;
 
 class HddSummarizer implements Summarizer
 {
-	public static function summarize(ItemWithFeatures $item): string
+	public static function summarize(ItemWithFeatures $item): array
 	{
 		$type = $item->getFeature('type');
 		$capacity = $item->getFeature('capacity-decibyte');
@@ -101,10 +101,6 @@ class HddSummarizer implements Summarizer
 
 		$commercial = PartialSummaries::summarizeCommercial($item);
 
-		$pretty = $hardware . ', ' . $procedures;
-		$pretty .= $commercial ? ', ' . $commercial : '';
-		$pretty .= $os ? ', ' . $os : '';
-
-		return $pretty;
+		return array_filter([$hardware, $procedures, $commercial, "$os"]);
 	}
 }

--- a/src/SSRv1/Summary/MonitorSummarizer.php
+++ b/src/SSRv1/Summary/MonitorSummarizer.php
@@ -7,7 +7,7 @@ use WEEEOpen\Tarallo\SSRv1\FeaturePrinter;
 
 class MonitorSummarizer implements Summarizer
 {
-	public static function summarize(ItemWithFeatures $item): string
+	public static function summarize(ItemWithFeatures $item): array
 	{
 		$type = $item->getFeature('type');
 		$psuAmpere = $item->getFeature('psu-ampere');
@@ -17,19 +17,15 @@ class MonitorSummarizer implements Summarizer
 		$type = FeaturePrinter::printableValue($type);
 		$type .= $diagonalInch ? ' ' . FeaturePrinter::printableValue($diagonalInch) : '';
 
-
 		$commercial = PartialSummaries::summarizeCommercial($item);
-		$commercial = $commercial ? ", $commercial" : '';
 
-		$ports = PartialSummaries::summarizePorts($item, false, ' ');
-		$ports = $ports ? ", $ports" : '';
+		$ports = PartialSummaries::summarizePorts($item, false, ', ');
 
-		$power = $psuAmpere ? ' ' . FeaturePrinter::printableValue($psuAmpere) : '';
-		$power .= $psuVolt ? ' ' . FeaturePrinter::printableValue($psuVolt) : '';
+		$power = $psuAmpere ? FeaturePrinter::printableValue($psuAmpere) : '';
+		$power .= $psuVolt ? ($power ? ' ' : '') . FeaturePrinter::printableValue($psuVolt) : '';
 		$powerPorts = PartialSummaries::summarizePowerconnectors($item, false, ' ');
 		$power .= $powerPorts ? " $powerPorts" : '';
-		$power = $power ? ",$power" : '';
 
-		return $type . $ports . $power . $commercial;
+		return array_filter([$type, $ports, $power, $commercial]);
 	}
 }

--- a/src/SSRv1/Summary/MotherboardSummarizer.php
+++ b/src/SSRv1/Summary/MotherboardSummarizer.php
@@ -5,9 +5,9 @@ namespace WEEEOpen\Tarallo\SSRv1\Summary;
 use WEEEOpen\Tarallo\ItemWithFeatures;
 use WEEEOpen\Tarallo\SSRv1\FeaturePrinter;
 
-class MotherboardSummarizer
+class MotherboardSummarizer implements Summarizer
 {
-	public static function summarize(ItemWithFeatures $item): string
+	public static function summarize(ItemWithFeatures $item): array
 	{
 		$type = $item->getFeature('type');
 		$socket = $item->getFeature('cpu-socket');
@@ -19,26 +19,21 @@ class MotherboardSummarizer
 
 		if ($socket) {
 			$value = FeaturePrinter::printableValue($socket);
-			if (substr($value, 0, 6) === 'Socket') {
-				$theWordSocketLiterally = '';
-			} else {
-				$theWordSocketLiterally = str_replace(' (CPU)', '', FeaturePrinter::printableName('cpu-socket')) . ' ';
+			if (!str_starts_with($value, "Socket")) {
+				$value = "Socket $value";
 			}
-			$type .= ' ' . $theWordSocketLiterally . $value;
+
+			$type .= " $value";
 		}
 
-		$ports = PartialSummaries::summarizePorts($item, false, ' ');
-		$ports = $ports ? ", $ports" : '';
+		$ports = PartialSummaries::summarizePorts($item, false, ', ');
 
-		$sockets = PartialSummaries::summarizeSockets($item, false, ' ');
-		$sockets = $sockets ? ", $sockets" : '';
+		$sockets = PartialSummaries::summarizeSockets($item, false, ', ');
 
-		$color = $color = $color ? ', ' . FeaturePrinter::printableValue($color) : '';
+		$color = $color ? FeaturePrinter::printableValue($color) : '';
 
 		$commercial = PartialSummaries::summarizeCommercial($item);
-		$commercial = $commercial ? ", $commercial" : '';
 
-		$pretty =  $type . $sockets . $ports . $color . $commercial;
-		return $pretty;
+		return array_filter([$type, $sockets, $ports, $color, $commercial]);
 	}
 }

--- a/src/SSRv1/Summary/OddSummarizer.php
+++ b/src/SSRv1/Summary/OddSummarizer.php
@@ -7,7 +7,7 @@ use WEEEOpen\Tarallo\SSRv1\FeaturePrinter;
 
 class OddSummarizer implements Summarizer
 {
-	public static function summarize(ItemWithFeatures $item): string
+	public static function summarize(ItemWithFeatures $item): array
 	{
 		$type = $item->getFeature('type');
 		$oddType = $item->getFeature('odd-type');
@@ -18,14 +18,12 @@ class OddSummarizer implements Summarizer
 		$type .= $formFactor ? ' ' . FeaturePrinter::printableValue($formFactor) : '';
 		$type .= $oddType ? ' ' . FeaturePrinter::printableValue($oddType) : '';
 
-		$color = $color ? ', ' . FeaturePrinter::printableValue($color) : '';
+		$color = $color ? FeaturePrinter::printableValue($color) : '';
 
 		$commercial = PartialSummaries::summarizeCommercial($item);
-		$commercial = $commercial ? ", $commercial" : '';
 
-		$ports = PartialSummaries::summarizePorts($item, true, ' ');
-		$ports = $ports ? ", $ports" : '';
+		$ports = PartialSummaries::summarizePorts($item, true, ', ');
 
-		return $type . $ports . $color . $commercial;
+		return array_filter([$type, $ports, $color, $commercial]);
 	}
 }

--- a/src/SSRv1/Summary/PsuSummarizer.php
+++ b/src/SSRv1/Summary/PsuSummarizer.php
@@ -7,7 +7,7 @@ use WEEEOpen\Tarallo\SSRv1\FeaturePrinter;
 
 class PsuSummarizer implements Summarizer
 {
-	public static function summarize(ItemWithFeatures $item): string
+	public static function summarize(ItemWithFeatures $item): array
 	{
 		$type = $item->getFeature('type');
 		$formFactor = $item->getFeature('psu-form-factor');
@@ -19,17 +19,16 @@ class PsuSummarizer implements Summarizer
 		$type = FeaturePrinter::printableValue($type);
 		$type .= $formFactor ? ' ' . FeaturePrinter::printableValue($formFactor) : '';
 		$type .= $powerWatt ? ' ' . FeaturePrinter::printableValue($powerWatt) : '';
-		$color = $color ? ', ' . FeaturePrinter::printableValue($color) : '';
+		$color = $color ? FeaturePrinter::printableValue($color) : '';
 
 
 		$power = PartialSummaries::summarizePowerconnectors($item);
 		$power .= $ampere ? ' ' . FeaturePrinter::printableValue($ampere) : '';
 		$power .= $volt ? ' ' . FeaturePrinter::printableValue($volt) : '';
-		$power = $power ? " ($power)" : '';
+		$power = $power ? "$power" : '';
 		$commercial = PartialSummaries::summarizeCommercial($item);
-		$commercial = $commercial ? ", $commercial" : '';
 
 		// TODO: finish this
-		return $type . $power . $color . $commercial;
+		return array_filter([$type, $power, $color, $commercial]);
 	}
 }

--- a/src/SSRv1/Summary/RamSummarizer.php
+++ b/src/SSRv1/Summary/RamSummarizer.php
@@ -7,7 +7,7 @@ use WEEEOpen\Tarallo\SSRv1\FeaturePrinter;
 
 class RamSummarizer implements Summarizer
 {
-	public static function summarize(ItemWithFeatures $item): string
+	public static function summarize(ItemWithFeatures $item): array
 	{
 		$ecc = $item->getFeature('ram-ecc');
 		if ($ecc === null) {
@@ -43,14 +43,7 @@ class RamSummarizer implements Summarizer
 			// Looks nicer
 			$technical = 'RAM';
 		}
-		if ($technical !== '' && $commercial !== '') {
-			$pretty = "$technical, $commercial";
-		} elseif ($technical !== '') {
-			$pretty = $technical;
-		} else {
-			$pretty = $commercial;
-		}
 
-		return $pretty;
+		return array_filter([$technical, $commercial]);
 	}
 }

--- a/src/SSRv1/Summary/SimpleDeviceSummarizer.php
+++ b/src/SSRv1/Summary/SimpleDeviceSummarizer.php
@@ -7,7 +7,7 @@ use WEEEOpen\Tarallo\SSRv1\FeaturePrinter;
 
 class SimpleDeviceSummarizer implements Summarizer
 {
-	public static function summarize(ItemWithFeatures $item): string
+	public static function summarize(ItemWithFeatures $item): array
 	{
 		$type = FeaturePrinter::printableValue($item->getFeature('type'));
 		$ports = PartialSummaries::summarizePorts($item, false, ' ');
@@ -15,19 +15,6 @@ class SimpleDeviceSummarizer implements Summarizer
 		$commercial = PartialSummaries::summarizeCommercial($item);
 		$color = $item->getFeature('color');
 
-		$pieces = [$type];
-		if ($ports !== '') {
-			$pieces[] = $ports;
-		}
-//		if($sockets !== '') {
-//			$pieces[] = $sockets;
-//		}
-		if ($color !== null) {
-			$pieces[] = FeaturePrinter::printableValue($color);
-		}
-		if ($commercial !== '') {
-			$pieces[] = $commercial;
-		}
-		return implode(', ', $pieces);
+		return array_filter([$type, $ports, $color ? FeaturePrinter::printableValue($color) : '', $commercial ]);
 	}
 }

--- a/src/SSRv1/Summary/SimplePortsSummarizer.php
+++ b/src/SSRv1/Summary/SimplePortsSummarizer.php
@@ -7,7 +7,7 @@ use WEEEOpen\Tarallo\SSRv1\FeaturePrinter;
 
 class SimplePortsSummarizer implements Summarizer
 {
-	public static function summarize(ItemWithFeatures $item): string
+	public static function summarize(ItemWithFeatures $item): array
 	{
 		$type = FeaturePrinter::printableValue($item->getFeature('type'));
 		$ports = PartialSummaries::summarizePorts($item, false, ' ');
@@ -15,19 +15,6 @@ class SimplePortsSummarizer implements Summarizer
 		$commercial = PartialSummaries::summarizeCommercial($item);
 		$color = $item->getFeature('color');
 
-		$pieces = [$type];
-		if ($ports !== '') {
-			$pieces[] = $ports;
-		}
-		if ($sockets !== '') {
-			$pieces[] = $sockets;
-		}
-		if ($color !== null) {
-			$pieces[] = FeaturePrinter::printableValue($color);
-		}
-		if ($commercial !== '') {
-			$pieces[] = $commercial;
-		}
-		return implode(', ', $pieces);
+		return array_filter([$type, $ports, $sockets, $color ? FeaturePrinter::printableValue($color) : '', $commercial]);
 	}
 }

--- a/src/SSRv1/Summary/Summarizer.php
+++ b/src/SSRv1/Summary/Summarizer.php
@@ -6,5 +6,5 @@ use WEEEOpen\Tarallo\ItemWithFeatures;
 
 interface Summarizer
 {
-	public static function summarize(ItemWithFeatures $item): string;
+	public static function summarize(ItemWithFeatures $item): array;
 }

--- a/src/SSRv1/Summary/Summary.php
+++ b/src/SSRv1/Summary/Summary.php
@@ -9,13 +9,13 @@ use WEEEOpen\Tarallo\SSRv1\FeaturePrinter;
 
 class Summary
 {
-	public static function peel(ItemWithFeatures $item): ?string
+	public static function peel(ItemWithFeatures $item): array
 	{
 		$type = $item->getFeature('type');
 		switch ($type) {
 			case null:
 				// Otherwise it breaks the summarizers
-				return 'Unknown item (set the type)';
+				return ['Unknown item (set the type)'];
 			case 'case':
 				return CaseSummarizer::summarize($item);
 			case 'motherboard':

--- a/src/SSRv1/templates/item.php
+++ b/src/SSRv1/templates/item.php
@@ -49,7 +49,7 @@ if (isset($edit)) {
 }
 
 $summary = \WEEEOpen\Tarallo\SSRv1\Summary\Summary::peel($item);
-$summary_escaped = array_map([$this, 'e'], explode(', ', $summary));
+$summary_escaped = array_map([$this, 'e'], $summary);
 unset($summary);
 
 $product = $item->getProduct();

--- a/src/SSRv1/templates/product.php
+++ b/src/SSRv1/templates/product.php
@@ -17,7 +17,7 @@ $this->layout(
 );
 
 $summary = \WEEEOpen\Tarallo\SSRv1\Summary\Summary::peel($product);
-$summary_escaped = array_map([$this, 'e'], explode(', ', $summary));
+$summary_escaped = array_map([$this, 'e'], $summary);
 unset($summary);
 
 $bmv_rawurlencoded = $this->e(rawurlencode($product->getBrand()) . '/' . rawurlencode($product->getModel()) . '/' . rawurlencode($product->getVariant()));

--- a/tests/SSRv1/Summary/CaseSummarizerTest.php
+++ b/tests/SSRv1/Summary/CaseSummarizerTest.php
@@ -1,15 +1,17 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
 use WEEEOpen\Tarallo\Feature;
 use WEEEOpen\Tarallo\Item;
 use WEEEOpen\Tarallo\SSRv1\Summary\CaseSummarizer;
+use WEEEOpen\TaralloTest\SSRv1\Summary\SummarizerTestCase;
 
 /**
  * @covers \WEEEOpen\Tarallo\SSRv1\Summary\CaseSummarizer
  */
-class CaseSummarizerTest extends TestCase {
-	public function testCase() {
+class CaseSummarizerTest extends SummarizerTestCase
+{
+	public function testCase()
+	{
 		$item = new Item('420');
 		$item
 			->addFeature(new Feature('color', 'white'))
@@ -21,15 +23,16 @@ class CaseSummarizerTest extends TestCase {
 			->addFeature(new Feature('motherboard-form-factor', 'atx'));
 
 		$summary = CaseSummarizer::summarize($item);
-		$this->assertEquals(
-			'Case ATX (4× USB), White, Asus Optiplex 755 SFF',
+		$this->assertArrayEquals(
+			["Case ATX", "4× USB", "White", "Asus Optiplex 755 SFF"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testCaseSinglePort() {
+	public function testCaseSinglePort()
+	{
 		$item = new Item('420');
 		$item
 			->addFeature(new Feature('color', 'grey'))
@@ -42,15 +45,16 @@ class CaseSummarizerTest extends TestCase {
 			->addFeature(new Feature('motherboard-form-factor', 'microatx'));
 
 		$summary = CaseSummarizer::summarize($item);
-		$this->assertEquals(
-			'Case Micro ATX (1× Firewire, 4× USB), Grey, HP AsdPC',
+		$this->assertArrayEquals(
+			["Case Micro ATX", "1× Firewire, 4× USB", "Grey", "HP AsdPC"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testCaseNoModel() {
+	public function testCaseNoModel()
+	{
 		$item = new Item('420');
 		$item
 			->addFeature(new Feature('color', 'white'))
@@ -61,15 +65,16 @@ class CaseSummarizerTest extends TestCase {
 			->addFeature(new Feature('motherboard-form-factor', 'atx'));
 
 		$summary = CaseSummarizer::summarize($item);
-		$this->assertEquals(
-			'Case ATX (4× USB), White, Asus',
+		$this->assertArrayEquals(
+			["Case ATX", "4× USB", "White", "Asus"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testCaseNoCommercial() {
+	public function testCaseNoCommercial()
+	{
 		$item = new Item('420');
 		$item
 			->addFeature(new Feature('color', 'white'))
@@ -79,15 +84,16 @@ class CaseSummarizerTest extends TestCase {
 			->addFeature(new Feature('motherboard-form-factor', 'atx'));
 
 		$summary = CaseSummarizer::summarize($item);
-		$this->assertEquals(
-			'Case ATX (4× USB), White',
+		$this->assertArrayEquals(
+			["Case ATX", "4× USB", "White"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testCaseNoColor() {
+	public function testCaseNoColor()
+	{
 		$item = new Item('420');
 		$item
 			->addFeature(new Feature('usb-ports-n', 4))
@@ -98,15 +104,16 @@ class CaseSummarizerTest extends TestCase {
 			->addFeature(new Feature('motherboard-form-factor', 'atx'));
 
 		$summary = CaseSummarizer::summarize($item);
-		$this->assertEquals(
-			'Case ATX (4× USB), Asus Optiplex 755 SFF',
+		$this->assertArrayEquals(
+			["Case ATX", "4× USB", "Asus Optiplex 755 SFF"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testCaseNoPorts() {
+	public function testCaseNoPorts()
+	{
 		$item = new Item('420');
 		$item
 			->addFeature(new Feature('color', 'white'))
@@ -117,15 +124,16 @@ class CaseSummarizerTest extends TestCase {
 			->addFeature(new Feature('motherboard-form-factor', 'atx'));
 
 		$summary = CaseSummarizer::summarize($item);
-		$this->assertEquals(
-			'Case ATX, White, Asus Optiplex 755 SFF',
+		$this->assertArrayEquals(
+			["Case ATX", "White", "Asus Optiplex 755 SFF"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testCaseNoPortsNoFormFactor() {
+	public function testCaseNoPortsNoFormFactor()
+	{
 		$item = new Item('420');
 		$item
 			->addFeature(new Feature('color', 'white'))
@@ -135,15 +143,16 @@ class CaseSummarizerTest extends TestCase {
 			->addFeature(new Feature('model', 'Optiplex 755 SFF'));
 
 		$summary = CaseSummarizer::summarize($item);
-		$this->assertEquals(
-			'Case, White, Asus Optiplex 755 SFF',
+		$this->assertArrayEquals(
+			["Case", "White", "Asus Optiplex 755 SFF"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testCaseNoFormFactor() {
+	public function testCaseNoFormFactor()
+	{
 		$item = new Item('420');
 		$item
 			->addFeature(new Feature('color', 'white'))
@@ -154,15 +163,16 @@ class CaseSummarizerTest extends TestCase {
 			->addFeature(new Feature('model', 'Optiplex 755 SFF'));
 
 		$summary = CaseSummarizer::summarize($item);
-		$this->assertEquals(
-			'Case (4× USB), White, Asus Optiplex 755 SFF',
+		$this->assertArrayEquals(
+			["Case", "4× USB", "White", "Asus Optiplex 755 SFF"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testCaseNoCommercialNoColor() {
+	public function testCaseNoCommercialNoColor()
+	{
 		$item = new Item('420');
 		$item
 			->addFeature(new Feature('usb-ports-n', 4))
@@ -171,15 +181,16 @@ class CaseSummarizerTest extends TestCase {
 			->addFeature(new Feature('motherboard-form-factor', 'atx'));
 
 		$summary = CaseSummarizer::summarize($item);
-		$this->assertEquals(
-			'Case ATX (4× USB)',
+		$this->assertArrayEquals(
+			["Case ATX", "4× USB"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testCaseNoCommercialNoColorNoPorts() {
+	public function testCaseNoCommercialNoColorNoPorts()
+	{
 		$item = new Item('420');
 		$item
 			->addFeature(new Feature('type', 'case'))
@@ -187,30 +198,32 @@ class CaseSummarizerTest extends TestCase {
 			->addFeature(new Feature('motherboard-form-factor', 'atx'));
 
 		$summary = CaseSummarizer::summarize($item);
-		$this->assertEquals(
-			'Case ATX',
+		$this->assertArrayEquals(
+			["Case ATX"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testCaseNothing() {
+	public function testCaseNothing()
+	{
 		$item = new Item('420');
 		$item
 			->addFeature(new Feature('type', 'case'))
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = CaseSummarizer::summarize($item);
-		$this->assertEquals(
-			'Case',
+		$this->assertArrayEquals(
+			["Case"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testCaseNoColorNoPortsNoFormFactor() {
+	public function testCaseNoColorNoPortsNoFormFactor()
+	{
 		$item = new Item('420');
 		$item
 			->addFeature(new Feature('type', 'case'))
@@ -219,16 +232,11 @@ class CaseSummarizerTest extends TestCase {
 			->addFeature(new Feature('model', 'Optiplex 755 SFF'));
 
 		$summary = CaseSummarizer::summarize($item);
-		$this->assertEquals(
-			'Case, Asus Optiplex 755 SFF',
+		$this->assertArrayEquals(
+			["Case", "Asus Optiplex 755 SFF"],
 			$summary
 		);
 
 		return $summary;
-
 	}
-
-
-
-
 }

--- a/tests/SSRv1/Summary/CpuSummarizerTest.php
+++ b/tests/SSRv1/Summary/CpuSummarizerTest.php
@@ -1,15 +1,17 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
 use WEEEOpen\Tarallo\Feature;
 use WEEEOpen\Tarallo\Item;
 use WEEEOpen\Tarallo\SSRv1\Summary\CpuSummarizer;
+use WEEEOpen\TaralloTest\SSRv1\Summary\SummarizerTestCase;
 
 /**
  * @covers \WEEEOpen\Tarallo\SSRv1\Summary\CpuSummarizer
  */
-class CpuSummarizerTest extends TestCase {
-	public function testCpu() {
+class CpuSummarizerTest extends SummarizerTestCase
+{
+	public function testCpu()
+	{
 		$item = new Item('C123');
 		$item
 			->addFeature(new Feature('brand', 'Intel'))
@@ -17,22 +19,23 @@ class CpuSummarizerTest extends TestCase {
 			->addFeature(new Feature('cpu-socket', 'lga775'))
 			->addFeature(new Feature('core-n', 2))
 			->addFeature(new Feature('thread-n', 2))
-			->addFeature(new Feature('frequency-hertz',2130000000))
+			->addFeature(new Feature('frequency-hertz', 2130000000))
 			->addFeature(new Feature('isa', 'x86-64'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('owner', 'Area IT'))
 			->addFeature(new Feature('type', 'cpu'));
 
 		$summary = CpuSummarizer::summarize($item);
-		$this->assertEquals(
-			'CPU x86 64 bit, 2 Cores 2 Threads @ 2.13 GHz, Socket LGA775, Intel Core 2 Duo E6400',
+		$this->assertArrayEquals(
+			["CPU x86 64 bit", "2 Cores 2 Threads @ 2.13 GHz", "Socket LGA775", "Intel Core 2 Duo E6400"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testCpu2c4t() {
+	public function testCpu2c4t()
+	{
 		$item = new Item('C123');
 		$item
 			->addFeature(new Feature('brand', 'Intel'))
@@ -40,22 +43,23 @@ class CpuSummarizerTest extends TestCase {
 			->addFeature(new Feature('cpu-socket', 'lga775'))
 			->addFeature(new Feature('core-n', 2))
 			->addFeature(new Feature('thread-n', 4))
-			->addFeature(new Feature('frequency-hertz',2130000000))
+			->addFeature(new Feature('frequency-hertz', 2130000000))
 			->addFeature(new Feature('isa', 'x86-64'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('owner', 'Area IT'))
 			->addFeature(new Feature('type', 'cpu'));
 
 		$summary = CpuSummarizer::summarize($item);
-		$this->assertEquals(
-			'CPU x86 64 bit, 2 Cores 4 Threads @ 2.13 GHz, Socket LGA775, Intel Core 2 Duo E6400',
+		$this->assertArrayEquals(
+			["CPU x86 64 bit", "2 Cores 4 Threads @ 2.13 GHz", "Socket LGA775", "Intel Core 2 Duo E6400"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testCpuNoFreq() {
+	public function testCpuNoFreq()
+	{
 		$item = new Item('C123');
 		$item
 			->addFeature(new Feature('brand', 'Intel'))
@@ -69,74 +73,78 @@ class CpuSummarizerTest extends TestCase {
 			->addFeature(new Feature('type', 'cpu'));
 
 		$summary = CpuSummarizer::summarize($item);
-		$this->assertEquals('CPU x86 64 bit, 2 Cores 2 Threads, Socket LGA775, Intel Core 2 Duo E6400', $summary);
+		$this->assertArrayEquals(["CPU x86 64 bit", "2 Cores 2 Threads", "Socket LGA775", "Intel Core 2 Duo E6400"], $summary);
 
 		return $summary;
 	}
 
-	public function testCpuNoThreads() {
+	public function testCpuNoThreads()
+	{
 		$item = new Item('C123');
 		$item
 			->addFeature(new Feature('brand', 'Intel'))
 			->addFeature(new Feature('model', 'Core 2 Duo E6400'))
 			->addFeature(new Feature('cpu-socket', 'lga775'))
 			->addFeature(new Feature('core-n', 2))
-			->addFeature(new Feature('frequency-hertz',2130000000))
+			->addFeature(new Feature('frequency-hertz', 2130000000))
 			->addFeature(new Feature('isa', 'x86-64'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('owner', 'Area IT'))
 			->addFeature(new Feature('type', 'cpu'));
 
 		$summary = CpuSummarizer::summarize($item);
-		$this->assertEquals(
-			'CPU x86 64 bit, 2 Cores @ 2.13 GHz, Socket LGA775, Intel Core 2 Duo E6400',
+		$this->assertArrayEquals(
+			["CPU x86 64 bit", "2 Cores @ 2.13 GHz", "Socket LGA775", "Intel Core 2 Duo E6400"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testCpuNoCores() {
+	public function testCpuNoCores()
+	{
 		$item = new Item('C123');
 		$item
 			->addFeature(new Feature('brand', 'Intel'))
 			->addFeature(new Feature('model', 'Core 2 Duo E6400'))
 			->addFeature(new Feature('cpu-socket', 'lga775'))
 			->addFeature(new Feature('thread-n', 2))
-			->addFeature(new Feature('frequency-hertz',2130000000))
+			->addFeature(new Feature('frequency-hertz', 2130000000))
 			->addFeature(new Feature('isa', 'x86-64'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('owner', 'Area IT'))
 			->addFeature(new Feature('type', 'cpu'));
 
 		$summary = CpuSummarizer::summarize($item);
-		$this->assertEquals(
-			'CPU x86 64 bit, 2 Threads @ 2.13 GHz, Socket LGA775, Intel Core 2 Duo E6400',
+		$this->assertArrayEquals(
+			["CPU x86 64 bit", "2 Threads @ 2.13 GHz", "Socket LGA775", "Intel Core 2 Duo E6400"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testCpuNoCoresNoThreads() {
+	public function testCpuNoCoresNoThreads()
+	{
 		$item = new Item('C123');
 		$item
 			->addFeature(new Feature('brand', 'Intel'))
 			->addFeature(new Feature('model', 'Core 2 Duo E6400'))
 			->addFeature(new Feature('cpu-socket', 'lga775'))
-			->addFeature(new Feature('frequency-hertz',2130000000))
+			->addFeature(new Feature('frequency-hertz', 2130000000))
 			->addFeature(new Feature('isa', 'x86-64'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('owner', 'Area IT'))
 			->addFeature(new Feature('type', 'cpu'));
 
 		$summary = CpuSummarizer::summarize($item);
-		$this->assertEquals('CPU x86 64 bit, 2.13 GHz, Socket LGA775, Intel Core 2 Duo E6400', $summary);
+		$this->assertArrayEquals(["CPU x86 64 bit", "2.13 GHz", "Socket LGA775", "Intel Core 2 Duo E6400"], $summary);
 
 		return $summary;
 	}
 
-	public function testCpuNoCoresNoThreadsNoFreq() {
+	public function testCpuNoCoresNoThreadsNoFreq()
+	{
 		$item = new Item('C123');
 		$item
 			->addFeature(new Feature('brand', 'Intel'))
@@ -148,107 +156,113 @@ class CpuSummarizerTest extends TestCase {
 			->addFeature(new Feature('type', 'cpu'));
 
 		$summary = CpuSummarizer::summarize($item);
-		$this->assertEquals('CPU x86 64 bit, Socket LGA775, Intel Core 2 Duo E6400', $summary);
+		$this->assertArrayEquals(["CPU x86 64 bit", "Socket LGA775", "Intel Core 2 Duo E6400"], $summary);
 
 		return $summary;
 	}
 
-	public function testCpuNoModel() {
+	public function testCpuNoModel()
+	{
 		$item = new Item('C123');
 		$item
 			->addFeature(new Feature('brand', 'Intel'))
 			->addFeature(new Feature('cpu-socket', 'lga775'))
 			->addFeature(new Feature('core-n', 2))
 			->addFeature(new Feature('thread-n', 2))
-			->addFeature(new Feature('frequency-hertz',2130000000))
+			->addFeature(new Feature('frequency-hertz', 2130000000))
 			->addFeature(new Feature('isa', 'x86-64'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('owner', 'Area IT'))
 			->addFeature(new Feature('type', 'cpu'));
 
 		$summary = CpuSummarizer::summarize($item);
-		$this->assertEquals('CPU x86 64 bit, 2 Cores 2 Threads @ 2.13 GHz, Socket LGA775, Intel', $summary);
+		$this->assertArrayEquals(["CPU x86 64 bit", "2 Cores 2 Threads @ 2.13 GHz", "Socket LGA775", "Intel"], $summary);
 
 		return $summary;
 	}
 
-	public function testCpuNoBrand() {
+	public function testCpuNoBrand()
+	{
 		$item = new Item('C123');
 		$item
 			->addFeature(new Feature('model', 'Core 2 Duo E6400'))
 			->addFeature(new Feature('cpu-socket', 'lga775'))
 			->addFeature(new Feature('core-n', 2))
 			->addFeature(new Feature('thread-n', 2))
-			->addFeature(new Feature('frequency-hertz',2130000000))
+			->addFeature(new Feature('frequency-hertz', 2130000000))
 			->addFeature(new Feature('isa', 'x86-64'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('owner', 'Area IT'))
 			->addFeature(new Feature('type', 'cpu'));
 
 		$summary = CpuSummarizer::summarize($item);
-		$this->assertEquals(
-			'CPU x86 64 bit, 2 Cores 2 Threads @ 2.13 GHz, Socket LGA775, Core 2 Duo E6400',
+		$this->assertArrayEquals(
+			["CPU x86 64 bit", "2 Cores 2 Threads @ 2.13 GHz", "Socket LGA775", "Core 2 Duo E6400"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testCpuNoCommercial() {
+	public function testCpuNoCommercial()
+	{
 		$item = new Item('C123');
 		$item
 			->addFeature(new Feature('cpu-socket', 'lga775'))
 			->addFeature(new Feature('core-n', 2))
 			->addFeature(new Feature('thread-n', 2))
-			->addFeature(new Feature('frequency-hertz',2130000000))
+			->addFeature(new Feature('frequency-hertz', 2130000000))
 			->addFeature(new Feature('isa', 'x86-64'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('owner', 'Area IT'))
 			->addFeature(new Feature('type', 'cpu'));
 
 		$summary = CpuSummarizer::summarize($item);
-		$this->assertEquals('CPU x86 64 bit, 2 Cores 2 Threads @ 2.13 GHz, Socket LGA775', $summary);
+		$this->assertArrayEquals(["CPU x86 64 bit", "2 Cores 2 Threads @ 2.13 GHz", "Socket LGA775"], $summary);
 
 		return $summary;
 	}
 
-	public function testCpuNoSocket() {
+	public function testCpuNoSocket()
+	{
 		$item = new Item('C123');
 		$item
 			->addFeature(new Feature('brand', 'Intel'))
 			->addFeature(new Feature('model', 'Core 2 Duo E6400'))
 			->addFeature(new Feature('core-n', 2))
 			->addFeature(new Feature('thread-n', 2))
-			->addFeature(new Feature('frequency-hertz',2130000000))
+			->addFeature(new Feature('frequency-hertz', 2130000000))
 			->addFeature(new Feature('isa', 'x86-64'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('owner', 'Area IT'))
 			->addFeature(new Feature('type', 'cpu'));
 
 		$summary = CpuSummarizer::summarize($item);
-		$this->assertEquals('CPU x86 64 bit, 2 Cores 2 Threads @ 2.13 GHz, Intel Core 2 Duo E6400', $summary);
+		$this->assertArrayEquals(["CPU x86 64 bit", "2 Cores 2 Threads @ 2.13 GHz", "Intel Core 2 Duo E6400"], $summary);
 
 		return $summary;
 	}
 
-	public function testCpuNoSocketNoCommercial() {
+	public function testCpuNoSocketNoCommercial()
+	{
 		$item = new Item('C123');
 		$item
 			->addFeature(new Feature('core-n', 2))
 			->addFeature(new Feature('thread-n', 2))
-			->addFeature(new Feature('frequency-hertz',2130000000))
+			->addFeature(new Feature('frequency-hertz', 2130000000))
 			->addFeature(new Feature('isa', 'x86-64'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('owner', 'Area IT'))
 			->addFeature(new Feature('type', 'cpu'));
 
 		$summary = CpuSummarizer::summarize($item);
-		$this->assertEquals('CPU x86 64 bit, 2 Cores 2 Threads @ 2.13 GHz', $summary);
+		$this->assertArrayEquals(["CPU x86 64 bit", "2 Cores 2 Threads @ 2.13 GHz"], $summary);
 
 		return $summary;
 	}
 
-	public function testCpuNoTechnical() {
+	public function testCpuNoTechnical()
+	{
 		$item = new Item('C123');
 		$item
 			->addFeature(new Feature('brand', 'Intel'))
@@ -260,12 +274,13 @@ class CpuSummarizerTest extends TestCase {
 			->addFeature(new Feature('type', 'cpu'));
 
 		$summary = CpuSummarizer::summarize($item);
-		$this->assertEquals('CPU x86 64 bit, Socket LGA775, Intel Core 2 Duo E6400', $summary);
+		$this->assertArrayEquals(["CPU x86 64 bit", "Socket LGA775", "Intel Core 2 Duo E6400"], $summary);
 
 		return $summary;
 	}
 
-	public function testCpuNoTechnicalNoSocket() {
+	public function testCpuNoTechnicalNoSocket()
+	{
 		$item = new Item('C123');
 		$item
 			->addFeature(new Feature('brand', 'Intel'))
@@ -276,12 +291,13 @@ class CpuSummarizerTest extends TestCase {
 			->addFeature(new Feature('type', 'cpu'));
 
 		$summary = CpuSummarizer::summarize($item);
-		$this->assertEquals('CPU x86 64 bit, Intel Core 2 Duo E6400', $summary);
+		$this->assertArrayEquals(["CPU x86 64 bit", "Intel Core 2 Duo E6400"], $summary);
 
 		return $summary;
 	}
 
-	public function testCpuNoArchitecture() {
+	public function testCpuNoArchitecture()
+	{
 		$item = new Item('C123');
 		$item
 			->addFeature(new Feature('brand', 'Intel'))
@@ -289,21 +305,22 @@ class CpuSummarizerTest extends TestCase {
 			->addFeature(new Feature('cpu-socket', 'lga775'))
 			->addFeature(new Feature('core-n', 2))
 			->addFeature(new Feature('thread-n', 2))
-			->addFeature(new Feature('frequency-hertz',2130000000))
+			->addFeature(new Feature('frequency-hertz', 2130000000))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('owner', 'Area IT'))
 			->addFeature(new Feature('type', 'cpu'));
 
 		$summary = CpuSummarizer::summarize($item);
-		$this->assertEquals(
-			'CPU (Architecture?), 2 Cores 2 Threads @ 2.13 GHz, Socket LGA775, Intel Core 2 Duo E6400',
+		$this->assertArrayEquals(
+			["CPU (Architecture?)", "2 Cores 2 Threads @ 2.13 GHz", "Socket LGA775", "Intel Core 2 Duo E6400"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testCpuAlmostUnknown() {
+	public function testCpuAlmostUnknown()
+	{
 		$item = new Item('C123');
 		$item
 			->addFeature(new Feature('brand', 'Intel'))
@@ -311,12 +328,13 @@ class CpuSummarizerTest extends TestCase {
 			->addFeature(new Feature('type', 'cpu'));
 
 		$summary = CpuSummarizer::summarize($item);
-		$this->assertEquals('CPU (Architecture?), Intel Pentium III', $summary);
+		$this->assertArrayEquals(["CPU (Architecture?)", "Intel Pentium III"], $summary);
 
 		return $summary;
 	}
 
-	public function testCpuNoNothing() {
+	public function testCpuNoNothing()
+	{
 		$item = new Item('C123');
 		$item
 			->addFeature(new Feature('working', 'yes'))
@@ -324,18 +342,19 @@ class CpuSummarizerTest extends TestCase {
 			->addFeature(new Feature('type', 'cpu'));
 
 		$summary = CpuSummarizer::summarize($item);
-		$this->assertEquals('CPU', $summary);
+		$this->assertArrayEquals(["CPU"], $summary);
 
 		return $summary;
 	}
 
-	public function testCpuWeirdBehavior() {
+	public function testCpuWeirdBehavior()
+	{
 		$item = new Item('C140');
 		$item
 			->addFeature(new Feature('type', 'cpu'))
 			->addFeature(new Feature('brand', 'Intel'))
 			->addFeature(new Feature('cpu-socket', 'slot1'))
-			->addFeature(new Feature('frequency-hertz',700000000))
+			->addFeature(new Feature('frequency-hertz', 700000000))
 			->addFeature(new Feature('isa', 'x86-32'))
 			->addFeature(new Feature('model', 'Pentium 3'))
 			->addFeature(new Feature('working', 'yes'))
@@ -344,46 +363,48 @@ class CpuSummarizerTest extends TestCase {
 		// Incorrect output:
 		// "CPU x86 32 bit, 700 MHz, Intel Pentium 3, Socket Slot"
 		$summary = CpuSummarizer::summarize($item);
-		$this->assertEquals('CPU x86 32 bit, 700 MHz, Socket Slot 1, Intel Pentium 3', $summary);
+		$this->assertArrayEquals(["CPU x86 32 bit", "700 MHz", "Socket Slot 1", "Intel Pentium 3"], $summary);
 
 		return $summary;
 	}
 
-	public function testCpuBrandAndFamilyOnly() {
+	public function testCpuBrandAndFamilyOnly()
+	{
 		$item = new Item('C123');
 		$item
 			->addFeature(new Feature('brand', 'Intel'))
 			->addFeature(new Feature('family', 'Core 2 Duo'))
 			->addFeature(new Feature('cpu-socket', 'lga775'))
-			->addFeature(new Feature('frequency-hertz',2400000000))
+			->addFeature(new Feature('frequency-hertz', 2400000000))
 			->addFeature(new Feature('isa', 'x86-64'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('owner', 'DISAT'))
 			->addFeature(new Feature('type', 'cpu'));
 
 		$summary = CpuSummarizer::summarize($item);
-		$this->assertEquals(
-			'CPU x86 64 bit, 2.4 GHz, Socket LGA775, Intel Core 2 Duo',
+		$this->assertArrayEquals(
+			["CPU x86 64 bit", "2.4 GHz", "Socket LGA775", "Intel Core 2 Duo"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testCpuFamilyOnly() {
+	public function testCpuFamilyOnly()
+	{
 		$item = new Item('C123');
 		$item
 			->addFeature(new Feature('family', 'Core 2 Duo'))
 			->addFeature(new Feature('cpu-socket', 'lga775'))
-			->addFeature(new Feature('frequency-hertz',2400000000))
+			->addFeature(new Feature('frequency-hertz', 2400000000))
 			->addFeature(new Feature('isa', 'x86-64'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('owner', 'DISAT'))
 			->addFeature(new Feature('type', 'cpu'));
 
 		$summary = CpuSummarizer::summarize($item);
-		$this->assertEquals(
-			'CPU x86 64 bit, 2.4 GHz, Socket LGA775, Core 2 Duo',
+		$this->assertArrayEquals(
+			["CPU x86 64 bit", "2.4 GHz", "Socket LGA775", "Core 2 Duo"],
 			$summary
 		);
 

--- a/tests/SSRv1/Summary/GraphicCardSummarizerTest.php
+++ b/tests/SSRv1/Summary/GraphicCardSummarizerTest.php
@@ -1,15 +1,17 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
 use WEEEOpen\Tarallo\Feature;
 use WEEEOpen\Tarallo\Item;
 use WEEEOpen\Tarallo\SSRv1\Summary\GraphicCardSummarizer;
+use WEEEOpen\TaralloTest\SSRv1\Summary\SummarizerTestCase;
 
 /**
  * @covers \WEEEOpen\Tarallo\SSRv1\Summary\GraphicCardSummarizer
  */
-class GraphicCardSummarizerTest extends TestCase {
-	public function testGraphicCard(){
+class GraphicCardSummarizerTest extends SummarizerTestCase
+{
+	public function testGraphicCard()
+	{
 		$item = new Item('SG69');
 		$item
 			->addFeature(new Feature('brand', 'Nvidia'))
@@ -27,13 +29,14 @@ class GraphicCardSummarizerTest extends TestCase {
 			->addFeature(new Feature('capacity-byte', 134217728));
 
 		$summary = GraphicCardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Graphics card PCI Express 128 MiB, 2× DVI 1× HDMI 1× S-Video, Green, Nvidia GeForce4 MX 440',
+		$this->assertArrayEquals(
+			["Graphics card PCI Express 128 MiB", "2× DVI, 1× HDMI, 1× S-Video", "Green", "Nvidia GeForce4 MX 440"],
 			$summary
 		);
 	}
 
-	public function testGraphicCardNoColor(){
+	public function testGraphicCardNoColor()
+	{
 		$item = new Item('SG69');
 		$item
 			->addFeature(new Feature('brand', 'Nvidia'))
@@ -50,13 +53,14 @@ class GraphicCardSummarizerTest extends TestCase {
 			->addFeature(new Feature('capacity-byte', 134217728));
 
 		$summary = GraphicCardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Graphics card PCI Express 128 MiB, 2× DVI 1× HDMI 1× S-Video, Nvidia GeForce4 MX 440',
+		$this->assertArrayEquals(
+			["Graphics card PCI Express 128 MiB", "2× DVI, 1× HDMI, 1× S-Video", "Nvidia GeForce4 MX 440"],
 			$summary
 		);
 	}
 
-	public function testGraphicCardNoBrand(){
+	public function testGraphicCardNoBrand()
+	{
 		$item = new Item('SG69');
 		$item
 			->addFeature(new Feature('model', 'GeForce4 MX 440'))
@@ -73,13 +77,14 @@ class GraphicCardSummarizerTest extends TestCase {
 			->addFeature(new Feature('capacity-byte', 134217728));
 
 		$summary = GraphicCardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Graphics card PCI Express 128 MiB, 2× DVI 1× HDMI 1× S-Video, Green, GeForce4 MX 440',
+		$this->assertArrayEquals(
+			["Graphics card PCI Express 128 MiB", "2× DVI, 1× HDMI, 1× S-Video", "Green", "GeForce4 MX 440"],
 			$summary
 		);
 	}
 
-	public function testGraphicCardNoModel(){
+	public function testGraphicCardNoModel()
+	{
 		$item = new Item('SG69');
 		$item
 			->addFeature(new Feature('brand', 'Nvidia'))
@@ -96,13 +101,14 @@ class GraphicCardSummarizerTest extends TestCase {
 			->addFeature(new Feature('capacity-byte', 134217728));
 
 		$summary = GraphicCardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Graphics card PCI Express 128 MiB, 2× DVI 1× HDMI 1× S-Video, Green, Nvidia',
+		$this->assertArrayEquals(
+			["Graphics card PCI Express 128 MiB", "2× DVI, 1× HDMI, 1× S-Video", "Green", "Nvidia"],
 			$summary
 		);
 	}
 
-	public function testGraphicCardNoCommercial(){
+	public function testGraphicCardNoCommercial()
+	{
 		$item = new Item('SG69');
 		$item
 			->addFeature(new Feature('color', 'green'))
@@ -118,13 +124,14 @@ class GraphicCardSummarizerTest extends TestCase {
 			->addFeature(new Feature('capacity-byte', 134217728));
 
 		$summary = GraphicCardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Graphics card PCI Express 128 MiB, 2× DVI 1× HDMI 1× S-Video, Green',
+		$this->assertArrayEquals(
+			["Graphics card PCI Express 128 MiB", "2× DVI, 1× HDMI, 1× S-Video", "Green"],
 			$summary
 		);
 	}
 
-	public function testGraphicCardNoCommercialNoColor(){
+	public function testGraphicCardNoCommercialNoColor()
+	{
 		$item = new Item('SG69');
 		$item
 			->addFeature(new Feature('owner', 'DISAT'))
@@ -139,38 +146,19 @@ class GraphicCardSummarizerTest extends TestCase {
 			->addFeature(new Feature('capacity-byte', 134217728));
 
 		$summary = GraphicCardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Graphics card PCI Express 128 MiB, 2× DVI 1× HDMI 1× S-Video',
+		$this->assertArrayEquals(
+			["Graphics card PCI Express 128 MiB", "2× DVI, 1× HDMI, 1× S-Video"],
 			$summary
 		);
 	}
 
-	public function testGraphicCardNoPorts(){
-		$item = new Item('SG69');
-		$item
-			->addFeature(new Feature('brand', 'Nvidia'))
-			->addFeature(new Feature('model', 'GeForce4 MX 440'))
-			->addFeature(new Feature('color', 'green'))
-			->addFeature(new Feature('owner', 'DISAT'))
-			->addFeature(new Feature('working', 'yes'))
-			->addFeature(new Feature('pci-low-profile', 'no'))
-			->addFeature(new Feature('sn', '314159265358'))
-			->addFeature(new Feature('type', 'graphics-card'))
-			->addFeature(new Feature('pcie-sockets-n', 1))
-			->addFeature(new Feature('capacity-byte', 134217728));
-
-		$summary = GraphicCardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Graphics card PCI Express 128 MiB, Green, Nvidia GeForce4 MX 440',
-			$summary
-		);
-	}
-
-	public function testGraphicCardNoPortsNoColor(){
+	public function testGraphicCardNoPorts()
+	{
 		$item = new Item('SG69');
 		$item
 			->addFeature(new Feature('brand', 'Nvidia'))
 			->addFeature(new Feature('model', 'GeForce4 MX 440'))
+			->addFeature(new Feature('color', 'green'))
 			->addFeature(new Feature('owner', 'DISAT'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('pci-low-profile', 'no'))
@@ -180,13 +168,35 @@ class GraphicCardSummarizerTest extends TestCase {
 			->addFeature(new Feature('capacity-byte', 134217728));
 
 		$summary = GraphicCardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Graphics card PCI Express 128 MiB, Nvidia GeForce4 MX 440',
+		$this->assertArrayEquals(
+			["Graphics card PCI Express 128 MiB", "Green", "Nvidia GeForce4 MX 440"],
 			$summary
 		);
 	}
 
-	public function testGraphicCardNoCapacity(){
+	public function testGraphicCardNoPortsNoColor()
+	{
+		$item = new Item('SG69');
+		$item
+			->addFeature(new Feature('brand', 'Nvidia'))
+			->addFeature(new Feature('model', 'GeForce4 MX 440'))
+			->addFeature(new Feature('owner', 'DISAT'))
+			->addFeature(new Feature('working', 'yes'))
+			->addFeature(new Feature('pci-low-profile', 'no'))
+			->addFeature(new Feature('sn', '314159265358'))
+			->addFeature(new Feature('type', 'graphics-card'))
+			->addFeature(new Feature('pcie-sockets-n', 1))
+			->addFeature(new Feature('capacity-byte', 134217728));
+
+		$summary = GraphicCardSummarizer::summarize($item);
+		$this->assertArrayEquals(
+			["Graphics card PCI Express 128 MiB", "Nvidia GeForce4 MX 440"],
+			$summary
+		);
+	}
+
+	public function testGraphicCardNoCapacity()
+	{
 		$item = new Item('SG69');
 		$item
 			->addFeature(new Feature('brand', 'Nvidia'))
@@ -203,13 +213,14 @@ class GraphicCardSummarizerTest extends TestCase {
 			->addFeature(new Feature('pcie-sockets-n', 1));
 
 		$summary = GraphicCardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Graphics card PCI Express, 2× DVI 1× HDMI 1× S-Video, Green, Nvidia GeForce4 MX 440',
+		$this->assertArrayEquals(
+			["Graphics card PCI Express", "2× DVI, 1× HDMI, 1× S-Video", "Green", "Nvidia GeForce4 MX 440"],
 			$summary
 		);
 	}
 
-	public function testGraphicCardNoSocket(){
+	public function testGraphicCardNoSocket()
+	{
 		$item = new Item('SG69');
 		$item
 			->addFeature(new Feature('brand', 'Nvidia'))
@@ -226,13 +237,14 @@ class GraphicCardSummarizerTest extends TestCase {
 			->addFeature(new Feature('capacity-byte', 134217728));
 
 		$summary = GraphicCardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Graphics card 128 MiB, 2× DVI 1× HDMI 1× S-Video, Green, Nvidia GeForce4 MX 440',
+		$this->assertArrayEquals(
+			["Graphics card 128 MiB", "2× DVI, 1× HDMI, 1× S-Video", "Green", "Nvidia GeForce4 MX 440"],
 			$summary
 		);
 	}
 
-	public function testGraphicCardNoSocketNoCapacity(){
+	public function testGraphicCardNoSocketNoCapacity()
+	{
 		$item = new Item('SG69');
 		$item
 			->addFeature(new Feature('brand', 'Nvidia'))
@@ -248,13 +260,14 @@ class GraphicCardSummarizerTest extends TestCase {
 			->addFeature(new Feature('type', 'graphics-card'));
 
 		$summary = GraphicCardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Graphics card, 2× DVI 1× HDMI 1× S-Video, Green, Nvidia GeForce4 MX 440',
+		$this->assertArrayEquals(
+			["Graphics card", "2× DVI, 1× HDMI, 1× S-Video", "Green", "Nvidia GeForce4 MX 440"],
 			$summary
 		);
 	}
 
-	public function testGraphicCardNoCommercialNoPorts(){
+	public function testGraphicCardNoCommercialNoPorts()
+	{
 		$item = new Item('SG69');
 		$item
 			->addFeature(new Feature('color', 'green'))
@@ -267,13 +280,14 @@ class GraphicCardSummarizerTest extends TestCase {
 			->addFeature(new Feature('capacity-byte', 134217728));
 
 		$summary = GraphicCardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Graphics card PCI Express 128 MiB, Green',
+		$this->assertArrayEquals(
+			["Graphics card PCI Express 128 MiB", "Green"],
 			$summary
 		);
 	}
 
-	public function testGraphicCardNoCommercialNoCapacityNoSocket(){
+	public function testGraphicCardNoCommercialNoCapacityNoSocket()
+	{
 		$item = new Item('SG69');
 		$item
 			->addFeature(new Feature('color', 'green'))
@@ -287,13 +301,14 @@ class GraphicCardSummarizerTest extends TestCase {
 			->addFeature(new Feature('type', 'graphics-card'));
 
 		$summary = GraphicCardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Graphics card, 2× DVI 1× HDMI 1× S-Video, Green',
+		$this->assertArrayEquals(
+			["Graphics card", "2× DVI, 1× HDMI, 1× S-Video", "Green"],
 			$summary
 		);
 	}
 
-	public function testGraphicCardNoCommercialNoCapacityNoSocketNoPorts(){
+	public function testGraphicCardNoCommercialNoCapacityNoSocketNoPorts()
+	{
 		$item = new Item('SG69');
 		$item
 			->addFeature(new Feature('color', 'green'))
@@ -304,21 +319,22 @@ class GraphicCardSummarizerTest extends TestCase {
 			->addFeature(new Feature('type', 'graphics-card'));
 
 		$summary = GraphicCardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Graphics card, Green',
+		$this->assertArrayEquals(
+			["Graphics card", "Green"],
 			$summary
 		);
 	}
 
-	public function testGraphicCardNothing(){
+	public function testGraphicCardNothing()
+	{
 		$item = new Item('SG69');
 		$item
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('type', 'graphics-card'));
 
 		$summary = GraphicCardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Graphics card',
+		$this->assertArrayEquals(
+			["Graphics card"],
 			$summary
 		);
 	}

--- a/tests/SSRv1/Summary/HddSummarizerTest.php
+++ b/tests/SSRv1/Summary/HddSummarizerTest.php
@@ -1,15 +1,17 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
 use WEEEOpen\Tarallo\Feature;
 use WEEEOpen\Tarallo\Item;
 use WEEEOpen\Tarallo\SSRv1\Summary\HddSummarizer;
+use WEEEOpen\TaralloTest\SSRv1\Summary\SummarizerTestCase;
 
 /**
  * @covers \WEEEOpen\Tarallo\SSRv1\Summary\HddSummarizer
  */
-class HddSummarizerTest extends TestCase {
-	public function testHdd() {
+class HddSummarizerTest extends SummarizerTestCase
+{
+	public function testHdd()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -29,12 +31,13 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB SATA 3.5 in. 7200 rpm, ESP, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD 80 GB SATA 3.5 in. 7200 rpm", "ESP", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}
 
-	public function testHdd2() {
+	public function testHdd2()
+	{
 		$item = new Item('H456');
 		$item
 			->addFeature(new Feature('brand', 'Western Digital'))
@@ -54,13 +57,16 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 40 GB SATA 2.5 in. 5400 rpm, ESP, Western Digital Caviar WD40ASD, Windows XP',
-			$summary);
+		$this->assertArrayEquals(
+			["HDD 40 GB SATA 2.5 in. 5400 rpm", "ESP", "Western Digital Caviar WD40ASD", "Windows XP"],
+			$summary
+		);
 
 		return $summary;
 	}
-	
-	public function testHddNoFamily() {
+
+	public function testHddNoFamily()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -79,12 +85,13 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB SATA 3.5 in. 7200 rpm, ESP, Seagate STM123456XYZ, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD 80 GB SATA 3.5 in. 7200 rpm", "ESP", "Seagate STM123456XYZ", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}
 
-	public function testHddNoCommercial() {
+	public function testHddNoCommercial()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('capacity-decibyte', 80000000000))
@@ -101,12 +108,13 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB SATA 3.5 in. 7200 rpm, ESP, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD 80 GB SATA 3.5 in. 7200 rpm", "ESP", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}
 
-	public function testHddNoOs() {
+	public function testHddNoOs()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -125,12 +133,13 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB SATA 3.5 in. 7200 rpm, ESP, Seagate Barracuda STM123456XYZ', $summary);
+		$this->assertArrayEquals(["HDD 80 GB SATA 3.5 in. 7200 rpm", "ESP", "Seagate Barracuda STM123456XYZ"], $summary);
 
 		return $summary;
 	}
 
-	public function testHddNoOsNoCommercial() {
+	public function testHddNoOsNoCommercial()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('capacity-decibyte', 80000000000))
@@ -146,12 +155,13 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB SATA 3.5 in. 7200 rpm, ESP', $summary);
+		$this->assertArrayEquals(["HDD 80 GB SATA 3.5 in. 7200 rpm", "ESP"], $summary);
 
 		return $summary;
 	}
 
-	public function testHdd2Sata() {
+	public function testHdd2Sata()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -171,12 +181,13 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB 2×SATA 3.5 in. 7200 rpm, ESP, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD 80 GB 2×SATA 3.5 in. 7200 rpm", "ESP", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}
 
-	public function testHddIde() {
+	public function testHddIde()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -196,12 +207,13 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB IDE/ATA 3.5 in. 7200 rpm, ESP, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD 80 GB IDE/ATA 3.5 in. 7200 rpm", "ESP", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}
 
-	public function testHddMiniIde() {
+	public function testHddMiniIde()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -221,15 +233,16 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals(
-			'HDD 80 GB Mini IDE 3.5 in. 7200 rpm, ESP, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS',
+		$this->assertArrayEquals(
+			["HDD 80 GB Mini IDE 3.5 in. 7200 rpm", "ESP", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testHddScsi() {
+	public function testHddScsi()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -249,12 +262,13 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB SCSI SCA2 (80 pin) 3.5 in. 7200 rpm, ESP, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD 80 GB SCSI SCA2 (80 pin) 3.5 in. 7200 rpm", "ESP", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}
 
-	public function testHddScsi2() {
+	public function testHddScsi2()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -274,12 +288,13 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB SCSI DB68 (68 pin) 3.5 in. 7200 rpm, ESP, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD 80 GB SCSI DB68 (68 pin) 3.5 in. 7200 rpm", "ESP", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}
 
-	public function testHddWTF() {
+	public function testHddWTF()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -300,12 +315,13 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB SATA + IDE/ATA 3.5 in. 7200 rpm, ESP, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD 80 GB SATA + IDE/ATA 3.5 in. 7200 rpm", "ESP", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}
 
-	public function testHddWTF2() {
+	public function testHddWTF2()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -327,13 +343,14 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB SATA + IDE/ATA + Mini IDE 3.5 in. 7200 rpm, ESP, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD 80 GB SATA + IDE/ATA + Mini IDE 3.5 in. 7200 rpm", "ESP", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}
 
 
-	public function testHddWTFThisIsAJoke() {
+	public function testHddWTFThisIsAJoke()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -355,12 +372,13 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB 2×SATA + 2×IDE/ATA + 2×Mini IDE 3.5 in. 7200 rpm, ESP, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD 80 GB 2×SATA + 2×IDE/ATA + 2×Mini IDE 3.5 in. 7200 rpm", "ESP", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}
 
-	public function testHddNotErased() {
+	public function testHddNotErased()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -379,12 +397,13 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB SATA 3.5 in. 7200 rpm, _SP, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD 80 GB SATA 3.5 in. 7200 rpm", "_SP", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}
 
-	public function testHddNoSmart() {
+	public function testHddNoSmart()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -403,12 +422,13 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB SATA 3.5 in. 7200 rpm, E_P, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD 80 GB SATA 3.5 in. 7200 rpm", "E_P", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}
 
-	public function testHddNoSurface() {
+	public function testHddNoSurface()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -427,12 +447,13 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB SATA 3.5 in. 7200 rpm, ES_, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD 80 GB SATA 3.5 in. 7200 rpm", "ES_", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}
 
-	public function testHddNoSmartScan() {
+	public function testHddNoSmartScan()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -450,13 +471,16 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB SATA 3.5 in. 7200 rpm, E__, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS',
-			$summary);
+		$this->assertArrayEquals(
+			["HDD 80 GB SATA 3.5 in. 7200 rpm", "E__", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"],
+			$summary
+		);
 
 		return $summary;
 	}
 
-	public function testHddNoProcedures() {
+	public function testHddNoProcedures()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -473,26 +497,30 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB SATA 3.5 in. 7200 rpm, ___, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS',
-			$summary);
+		$this->assertArrayEquals(
+			["HDD 80 GB SATA 3.5 in. 7200 rpm", "___", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"],
+			$summary
+		);
 
 		return $summary;
 	}
 
 
-	public function testHddNothing() {
+	public function testHddNothing()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('type', 'hdd'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD, ___', $summary);
+		$this->assertArrayEquals(["HDD", "___"], $summary);
 
 		return $summary;
 	}
 
 
-	public function testHddSmartOld() {
+	public function testHddSmartOld()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -512,13 +540,14 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB SATA 3.5 in. 7200 rpm, EOP, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD 80 GB SATA 3.5 in. 7200 rpm", "EOP", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}
 
 
-	public function testHddScanFail() {
+	public function testHddScanFail()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -538,13 +567,14 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB SATA 3.5 in. 7200 rpm, ESX, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD 80 GB SATA 3.5 in. 7200 rpm", "ESX", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}
 
 
-	public function testHddSmartFailed() {
+	public function testHddSmartFailed()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -564,13 +594,14 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB SATA 3.5 in. 7200 rpm, EXP, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD 80 GB SATA 3.5 in. 7200 rpm", "EXP", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}
 
 
-	public function testHddNoFF() {
+	public function testHddNoFF()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -589,12 +620,13 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB SATA 7200 rpm, ESP, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD 80 GB SATA 7200 rpm", "ESP", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}
 
-	public function testHddNoRpm() {
+	public function testHddNoRpm()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -613,12 +645,13 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB SATA 3.5 in., ESP, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD 80 GB SATA 3.5 in.", "ESP", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}
 
-	public function testHddNoCapacity() {
+	public function testHddNoCapacity()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -637,11 +670,13 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD SATA 3.5 in. 7200 rpm, ESP, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD SATA 3.5 in. 7200 rpm", "ESP", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}
-	public function testHddNoPortos() {
+
+	public function testHddNoPortos()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -660,12 +695,13 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB 3.5 in. 7200 rpm, ESP, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD 80 GB 3.5 in. 7200 rpm", "ESP", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}
 
-	public function testHddMissingData() {
+	public function testHddMissingData()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -683,12 +719,13 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD 80 GB 3.5 in., ESP, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD 80 GB 3.5 in.", "ESP", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}
 
-	public function testHddMissingData2() {
+	public function testHddMissingData2()
+	{
 		$item = new Item('H123');
 		$item
 			->addFeature(new Feature('brand', 'Seagate'))
@@ -704,7 +741,7 @@ class HddSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = HddSummarizer::summarize($item);
-		$this->assertEquals('HDD, ESP, Seagate Barracuda STM123456XYZ, Xubuntu 18.04 LTS', $summary);
+		$this->assertArrayEquals(["HDD", "ESP", "Seagate Barracuda STM123456XYZ", "Xubuntu 18.04 LTS"], $summary);
 
 		return $summary;
 	}

--- a/tests/SSRv1/Summary/MonitorSummarizerTest.php
+++ b/tests/SSRv1/Summary/MonitorSummarizerTest.php
@@ -1,22 +1,24 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
 use WEEEOpen\Tarallo\Feature;
 use WEEEOpen\Tarallo\Item;
 use WEEEOpen\Tarallo\SSRv1\Summary\MonitorSummarizer;
+use WEEEOpen\TaralloTest\SSRv1\Summary\SummarizerTestCase;
 
 /**
  * @covers \WEEEOpen\Tarallo\SSRv1\Summary\MonitorSummarizer
  */
-class MonitorSummarizerTest extends TestCase {
-	public function testMonitor() {
+class MonitorSummarizerTest extends SummarizerTestCase
+{
+	public function testMonitor()
+	{
 		$item = new Item('V9');
 		$item
 			->addFeature(new Feature('brand', 'Dell'))
 			->addFeature(new Feature('type', 'monitor'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('model', '1707FPt'))
-			->addFeature(new Feature('diagonal-inch', (double)14))
+			->addFeature(new Feature('diagonal-inch', (double) 14))
 			->addFeature(new Feature('dvi-ports-n', 1))
 			->addFeature(new Feature('usb-ports-n', 2))
 			->addFeature(new Feature('vga-ports-n', 1))
@@ -25,15 +27,16 @@ class MonitorSummarizerTest extends TestCase {
 			->addFeature(new Feature('psu-volt', (double) 12));
 
 		$summary = MonitorSummarizer::summarize($item);
-		$this->assertEquals(
-			'Monitor 14 in., 1× DVI 2× USB 1× VGA, 4 A 12 V C13/C14, Dell 1707FPt',
+		$this->assertArrayEquals(
+			["Monitor 14 in.", "1× DVI, 2× USB, 1× VGA", "4 A 12 V C13/C14", "Dell 1707FPt"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMonitorNoInch() {
+	public function testMonitorNoInch()
+	{
 		$item = new Item('V9');
 		$item
 			->addFeature(new Feature('brand', 'Dell'))
@@ -48,22 +51,23 @@ class MonitorSummarizerTest extends TestCase {
 			->addFeature(new Feature('psu-volt', (double) 12));
 
 		$summary = MonitorSummarizer::summarize($item);
-		$this->assertEquals(
-			'Monitor, 1× DVI 2× USB 1× VGA, 4 A 12 V C13/C14, Dell 1707FPt',
+		$this->assertArrayEquals(
+			["Monitor", "1× DVI, 2× USB, 1× VGA", "4 A 12 V C13/C14", "Dell 1707FPt"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMonitorNoVGA() {
+	public function testMonitorNoVGA()
+	{
 		$item = new Item('V9');
 		$item
 			->addFeature(new Feature('brand', 'Dell'))
 			->addFeature(new Feature('type', 'monitor'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('model', '1707FPt'))
-			->addFeature(new Feature('diagonal-inch', (double)14))
+			->addFeature(new Feature('diagonal-inch', (double) 14))
 			->addFeature(new Feature('dvi-ports-n', 1))
 			->addFeature(new Feature('usb-ports-n', 2))
 			->addFeature(new Feature('power-connector', 'c13'))
@@ -71,22 +75,23 @@ class MonitorSummarizerTest extends TestCase {
 			->addFeature(new Feature('psu-volt', (double) 12));
 
 		$summary = MonitorSummarizer::summarize($item);
-		$this->assertEquals(
-			'Monitor 14 in., 1× DVI 2× USB, 4 A 12 V C13/C14, Dell 1707FPt',
+		$this->assertArrayEquals(
+			["Monitor 14 in.", "1× DVI, 2× USB", "4 A 12 V C13/C14", "Dell 1707FPt"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMonitorNoDVI() {
+	public function testMonitorNoDVI()
+	{
 		$item = new Item('V9');
 		$item
 			->addFeature(new Feature('brand', 'Dell'))
 			->addFeature(new Feature('type', 'monitor'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('model', '1707FPt'))
-			->addFeature(new Feature('diagonal-inch', (double)14))
+			->addFeature(new Feature('diagonal-inch', (double) 14))
 			->addFeature(new Feature('usb-ports-n', 2))
 			->addFeature(new Feature('vga-ports-n', 1))
 			->addFeature(new Feature('power-connector', 'c13'))
@@ -94,22 +99,23 @@ class MonitorSummarizerTest extends TestCase {
 			->addFeature(new Feature('psu-volt', (double) 12));
 
 		$summary = MonitorSummarizer::summarize($item);
-		$this->assertEquals(
-			'Monitor 14 in., 2× USB 1× VGA, 4 A 12 V C13/C14, Dell 1707FPt',
+		$this->assertArrayEquals(
+			["Monitor 14 in.", "2× USB, 1× VGA", "4 A 12 V C13/C14", "Dell 1707FPt"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMonitorNoUSB() {
+	public function testMonitorNoUSB()
+	{
 		$item = new Item('V9');
 		$item
 			->addFeature(new Feature('brand', 'Dell'))
 			->addFeature(new Feature('type', 'monitor'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('model', '1707FPt'))
-			->addFeature(new Feature('diagonal-inch', (double)14))
+			->addFeature(new Feature('diagonal-inch', (double) 14))
 			->addFeature(new Feature('dvi-ports-n', 1))
 			->addFeature(new Feature('vga-ports-n', 1))
 			->addFeature(new Feature('power-connector', 'c13'))
@@ -117,43 +123,45 @@ class MonitorSummarizerTest extends TestCase {
 			->addFeature(new Feature('psu-volt', (double) 12));
 
 		$summary = MonitorSummarizer::summarize($item);
-		$this->assertEquals(
-			'Monitor 14 in., 1× DVI 1× VGA, 4 A 12 V C13/C14, Dell 1707FPt',
+		$this->assertArrayEquals(
+			["Monitor 14 in.", "1× DVI, 1× VGA", "4 A 12 V C13/C14", "Dell 1707FPt"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMonitorNoPorts() {
+	public function testMonitorNoPorts()
+	{
 		$item = new Item('V9');
 		$item
 			->addFeature(new Feature('brand', 'Dell'))
 			->addFeature(new Feature('type', 'monitor'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('model', '1707FPt'))
-			->addFeature(new Feature('diagonal-inch', (double)14))
+			->addFeature(new Feature('diagonal-inch', (double) 14))
 			->addFeature(new Feature('power-connector', 'c13'))
 			->addFeature(new Feature('psu-ampere', (double) 4))
 			->addFeature(new Feature('psu-volt', (double) 12));
 
 		$summary = MonitorSummarizer::summarize($item);
-		$this->assertEquals(
-			'Monitor 14 in., 4 A 12 V C13/C14, Dell 1707FPt',
+		$this->assertArrayEquals(
+			["Monitor 14 in.", "4 A 12 V C13/C14", "Dell 1707FPt"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMonitorNoAmpere() {
+	public function testMonitorNoAmpere()
+	{
 		$item = new Item('V9');
 		$item
 			->addFeature(new Feature('brand', 'Dell'))
 			->addFeature(new Feature('type', 'monitor'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('model', '1707FPt'))
-			->addFeature(new Feature('diagonal-inch', (double)14))
+			->addFeature(new Feature('diagonal-inch', (double) 14))
 			->addFeature(new Feature('dvi-ports-n', 1))
 			->addFeature(new Feature('usb-ports-n', 2))
 			->addFeature(new Feature('vga-ports-n', 1))
@@ -161,20 +169,23 @@ class MonitorSummarizerTest extends TestCase {
 			->addFeature(new Feature('psu-volt', (double) 12));
 
 		$summary = MonitorSummarizer::summarize($item);
-		$this->assertEquals(
-			'Monitor 14 in., 1× DVI 2× USB 1× VGA, 12 V C13/C14, Dell 1707FPt',
+		$this->assertArrayEquals(
+			["Monitor 14 in.", "1× DVI, 2× USB, 1× VGA", "12 V C13/C14", "Dell 1707FPt"],
 			$summary
 		);
 
 		return $summary;
-	}	public function testMonitorNoVolt() {
+	}
+
+	public function testMonitorNoVolt()
+	{
 		$item = new Item('V9');
 		$item
 			->addFeature(new Feature('brand', 'Dell'))
 			->addFeature(new Feature('type', 'monitor'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('model', '1707FPt'))
-			->addFeature(new Feature('diagonal-inch', (double)14))
+			->addFeature(new Feature('diagonal-inch', (double) 14))
 			->addFeature(new Feature('dvi-ports-n', 1))
 			->addFeature(new Feature('usb-ports-n', 2))
 			->addFeature(new Feature('vga-ports-n', 1))
@@ -182,20 +193,23 @@ class MonitorSummarizerTest extends TestCase {
 			->addFeature(new Feature('psu-ampere', (double) 4));
 
 		$summary = MonitorSummarizer::summarize($item);
-		$this->assertEquals(
-			'Monitor 14 in., 1× DVI 2× USB 1× VGA, 4 A C13/C14, Dell 1707FPt',
+		$this->assertArrayEquals(
+			["Monitor 14 in.", "1× DVI, 2× USB, 1× VGA", "4 A C13/C14", "Dell 1707FPt"],
 			$summary
 		);
 
 		return $summary;
-	}	public function testMonitorNoConnector() {
+	}
+
+	public function testMonitorNoConnector()
+	{
 		$item = new Item('V9');
 		$item
 			->addFeature(new Feature('brand', 'Dell'))
 			->addFeature(new Feature('type', 'monitor'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('model', '1707FPt'))
-			->addFeature(new Feature('diagonal-inch', (double)14))
+			->addFeature(new Feature('diagonal-inch', (double) 14))
 			->addFeature(new Feature('dvi-ports-n', 1))
 			->addFeature(new Feature('usb-ports-n', 2))
 			->addFeature(new Feature('vga-ports-n', 1))
@@ -203,42 +217,44 @@ class MonitorSummarizerTest extends TestCase {
 			->addFeature(new Feature('psu-volt', (double) 12));
 
 		$summary = MonitorSummarizer::summarize($item);
-		$this->assertEquals(
-			'Monitor 14 in., 1× DVI 2× USB 1× VGA, 4 A 12 V, Dell 1707FPt',
+		$this->assertArrayEquals(
+			["Monitor 14 in.", "1× DVI, 2× USB, 1× VGA", "4 A 12 V", "Dell 1707FPt"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMonitorNoPower() {
+	public function testMonitorNoPower()
+	{
 		$item = new Item('V9');
 		$item
 			->addFeature(new Feature('brand', 'Dell'))
 			->addFeature(new Feature('type', 'monitor'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('model', '1707FPt'))
-			->addFeature(new Feature('diagonal-inch', (double)14))
+			->addFeature(new Feature('diagonal-inch', (double) 14))
 			->addFeature(new Feature('dvi-ports-n', 1))
 			->addFeature(new Feature('usb-ports-n', 2))
 			->addFeature(new Feature('vga-ports-n', 1));
 
 		$summary = MonitorSummarizer::summarize($item);
-		$this->assertEquals(
-			'Monitor 14 in., 1× DVI 2× USB 1× VGA, Dell 1707FPt',
+		$this->assertArrayEquals(
+			["Monitor 14 in.", "1× DVI, 2× USB, 1× VGA", "Dell 1707FPt"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMonitorNoBrand() {
+	public function testMonitorNoBrand()
+	{
 		$item = new Item('V9');
 		$item
 			->addFeature(new Feature('type', 'monitor'))
 			->addFeature(new Feature('working', 'yes'))
 			->addFeature(new Feature('model', '1707FPt'))
-			->addFeature(new Feature('diagonal-inch', (double)14))
+			->addFeature(new Feature('diagonal-inch', (double) 14))
 			->addFeature(new Feature('dvi-ports-n', 1))
 			->addFeature(new Feature('usb-ports-n', 2))
 			->addFeature(new Feature('vga-ports-n', 1))
@@ -247,21 +263,22 @@ class MonitorSummarizerTest extends TestCase {
 			->addFeature(new Feature('psu-volt', (double) 12));
 
 		$summary = MonitorSummarizer::summarize($item);
-		$this->assertEquals(
-			'Monitor 14 in., 1× DVI 2× USB 1× VGA, 4 A 12 V C13/C14, 1707FPt',
+		$this->assertArrayEquals(
+			["Monitor 14 in.", "1× DVI, 2× USB, 1× VGA", "4 A 12 V C13/C14", "1707FPt"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMonitorNoModel() {
+	public function testMonitorNoModel()
+	{
 		$item = new Item('V9');
 		$item
 			->addFeature(new Feature('brand', 'Dell'))
 			->addFeature(new Feature('type', 'monitor'))
 			->addFeature(new Feature('working', 'yes'))
-			->addFeature(new Feature('diagonal-inch', (double)14))
+			->addFeature(new Feature('diagonal-inch', (double) 14))
 			->addFeature(new Feature('dvi-ports-n', 1))
 			->addFeature(new Feature('usb-ports-n', 2))
 			->addFeature(new Feature('vga-ports-n', 1))
@@ -270,20 +287,21 @@ class MonitorSummarizerTest extends TestCase {
 			->addFeature(new Feature('psu-volt', (double) 12));
 
 		$summary = MonitorSummarizer::summarize($item);
-		$this->assertEquals(
-			'Monitor 14 in., 1× DVI 2× USB 1× VGA, 4 A 12 V C13/C14, Dell',
+		$this->assertArrayEquals(
+			["Monitor 14 in.", "1× DVI, 2× USB, 1× VGA", "4 A 12 V C13/C14", "Dell"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMonitorNoCommercial() {
+	public function testMonitorNoCommercial()
+	{
 		$item = new Item('V9');
 		$item
 			->addFeature(new Feature('type', 'monitor'))
 			->addFeature(new Feature('working', 'yes'))
-			->addFeature(new Feature('diagonal-inch', (double)14))
+			->addFeature(new Feature('diagonal-inch', (double) 14))
 			->addFeature(new Feature('dvi-ports-n', 1))
 			->addFeature(new Feature('usb-ports-n', 2))
 			->addFeature(new Feature('vga-ports-n', 1))
@@ -292,61 +310,64 @@ class MonitorSummarizerTest extends TestCase {
 			->addFeature(new Feature('psu-volt', (double) 12));
 
 		$summary = MonitorSummarizer::summarize($item);
-		$this->assertEquals(
-			'Monitor 14 in., 1× DVI 2× USB 1× VGA, 4 A 12 V C13/C14',
+		$this->assertArrayEquals(
+			["Monitor 14 in.", "1× DVI, 2× USB, 1× VGA", "4 A 12 V C13/C14"],
 			$summary
 		);
 
 		return $summary;
 	}
-	public function testMonitorNoCommercialNoPower() {
+
+	public function testMonitorNoCommercialNoPower()
+	{
 		$item = new Item('V9');
 		$item
 			->addFeature(new Feature('type', 'monitor'))
 			->addFeature(new Feature('working', 'yes'))
-			->addFeature(new Feature('diagonal-inch', (double)14))
+			->addFeature(new Feature('diagonal-inch', (double) 14))
 			->addFeature(new Feature('dvi-ports-n', 1))
 			->addFeature(new Feature('usb-ports-n', 2))
 			->addFeature(new Feature('vga-ports-n', 1));
 
 		$summary = MonitorSummarizer::summarize($item);
-		$this->assertEquals(
-			'Monitor 14 in., 1× DVI 2× USB 1× VGA',
+		$this->assertArrayEquals(
+			["Monitor 14 in.", "1× DVI, 2× USB, 1× VGA"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMonitorNoCommercialNoPowerNoPorts() {
+	public function testMonitorNoCommercialNoPowerNoPorts()
+	{
 		$item = new Item('V9');
 		$item
 			->addFeature(new Feature('type', 'monitor'))
 			->addFeature(new Feature('working', 'yes'))
-			->addFeature(new Feature('diagonal-inch', (double)14));
+			->addFeature(new Feature('diagonal-inch', (double) 14));
 
 		$summary = MonitorSummarizer::summarize($item);
-		$this->assertEquals(
-			'Monitor 14 in.',
+		$this->assertArrayEquals(
+			["Monitor 14 in."],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMonitorNothing() {
+	public function testMonitorNothing()
+	{
 		$item = new Item('V9');
 		$item
 			->addFeature(new Feature('type', 'monitor'))
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = MonitorSummarizer::summarize($item);
-		$this->assertEquals(
-			'Monitor',
+		$this->assertArrayEquals(
+			["Monitor"],
 			$summary
 		);
 
 		return $summary;
 	}
-
 }

--- a/tests/SSRv1/Summary/MotherboardSummarizerTest.php
+++ b/tests/SSRv1/Summary/MotherboardSummarizerTest.php
@@ -1,15 +1,17 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
 use WEEEOpen\Tarallo\Feature;
 use WEEEOpen\Tarallo\Item;
 use WEEEOpen\Tarallo\SSRv1\Summary\MotherboardSummarizer;
+use WEEEOpen\TaralloTest\SSRv1\Summary\SummarizerTestCase;
 
 /**
  * @covers \WEEEOpen\Tarallo\SSRv1\Summary\MotherboardSummarizer
  */
-class MotherboardSummarizerTest extends TestCase {
-	public function testMotherboard() {
+class MotherboardSummarizerTest extends SummarizerTestCase
+{
+	public function testMotherboard()
+	{
 		$item = new Item('B55');
 		$item
 			->addFeature(new Feature('type', 'motherboard'))
@@ -26,15 +28,16 @@ class MotherboardSummarizerTest extends TestCase {
 			->addFeature(new Feature('pcie-sockets-n', 3));
 
 		$summary = MotherboardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Motherboard Micro ATX Socket 478 (desktop mPGA478B), 1× PCI 3× PCI Express, 1× IDE/ATA 4× USB 1× VGA, Red, Compaq D845GVFT',
+		$this->assertArrayEquals(
+			["Motherboard Micro ATX Socket 478 (desktop mPGA478B)", "1× PCI, 3× PCI Express", "1× IDE/ATA, 4× USB, 1× VGA", "Red", "Compaq D845GVFT"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMotherboardNoSockets() {
+	public function testMotherboardNoSockets()
+	{
 		$item = new Item('B55');
 		$item
 			->addFeature(new Feature('type', 'motherboard'))
@@ -48,15 +51,16 @@ class MotherboardSummarizerTest extends TestCase {
 			->addFeature(new Feature('ide-ports-n', 1));
 
 		$summary = MotherboardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Motherboard Micro ATX, 1× IDE/ATA 4× USB 1× VGA, Red, Compaq D845GVFT',
+		$this->assertArrayEquals(
+			["Motherboard Micro ATX", "1× IDE/ATA, 4× USB, 1× VGA", "Red", "Compaq D845GVFT"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMotherboardNoPorts() {
+	public function testMotherboardNoPorts()
+	{
 		$item = new Item('B55');
 		$item
 			->addFeature(new Feature('type', 'motherboard'))
@@ -70,15 +74,16 @@ class MotherboardSummarizerTest extends TestCase {
 			->addFeature(new Feature('pcie-sockets-n', 3));
 
 		$summary = MotherboardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Motherboard Micro ATX Socket 478 (desktop mPGA478B), 1× PCI 3× PCI Express, Red, Compaq D845GVFT',
+		$this->assertArrayEquals(
+			["Motherboard Micro ATX Socket 478 (desktop mPGA478B)", "1× PCI, 3× PCI Express", "Red", "Compaq D845GVFT"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMotherboardNoColor() {
+	public function testMotherboardNoColor()
+	{
 		$item = new Item('B55');
 		$item
 			->addFeature(new Feature('type', 'motherboard'))
@@ -94,15 +99,16 @@ class MotherboardSummarizerTest extends TestCase {
 			->addFeature(new Feature('pcie-sockets-n', 3));
 
 		$summary = MotherboardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Motherboard Micro ATX Socket 478 (desktop mPGA478B), 1× PCI 3× PCI Express, 1× IDE/ATA 4× USB 1× VGA, Compaq D845GVFT',
+		$this->assertArrayEquals(
+			["Motherboard Micro ATX Socket 478 (desktop mPGA478B)", "1× PCI, 3× PCI Express", "1× IDE/ATA, 4× USB, 1× VGA", "Compaq D845GVFT"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMotherboardNoColorNoCommercial() {
+	public function testMotherboardNoColorNoCommercial()
+	{
 		$item = new Item('B55');
 		$item
 			->addFeature(new Feature('type', 'motherboard'))
@@ -116,15 +122,16 @@ class MotherboardSummarizerTest extends TestCase {
 			->addFeature(new Feature('pcie-sockets-n', 3));
 
 		$summary = MotherboardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Motherboard Micro ATX Socket 478 (desktop mPGA478B), 1× PCI 3× PCI Express, 1× IDE/ATA 4× USB 1× VGA',
+		$this->assertArrayEquals(
+			["Motherboard Micro ATX Socket 478 (desktop mPGA478B)", "1× PCI, 3× PCI Express", "1× IDE/ATA, 4× USB, 1× VGA"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMotherboardNoFormFactor() {
+	public function testMotherboardNoFormFactor()
+	{
 		$item = new Item('B55');
 		$item
 			->addFeature(new Feature('type', 'motherboard'))
@@ -140,15 +147,16 @@ class MotherboardSummarizerTest extends TestCase {
 			->addFeature(new Feature('pcie-sockets-n', 3));
 
 		$summary = MotherboardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Motherboard Socket 478 (desktop mPGA478B), 1× PCI 3× PCI Express, 1× IDE/ATA 4× USB 1× VGA, Red, Compaq D845GVFT',
+		$this->assertArrayEquals(
+			["Motherboard Socket 478 (desktop mPGA478B)", "1× PCI, 3× PCI Express", "1× IDE/ATA, 4× USB, 1× VGA", "Red", "Compaq D845GVFT"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMotherboardNoBrand() {
+	public function testMotherboardNoBrand()
+	{
 		$item = new Item('B55');
 		$item
 			->addFeature(new Feature('type', 'motherboard'))
@@ -164,15 +172,16 @@ class MotherboardSummarizerTest extends TestCase {
 			->addFeature(new Feature('pcie-sockets-n', 3));
 
 		$summary = MotherboardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Motherboard Micro ATX Socket 478 (desktop mPGA478B), 1× PCI 3× PCI Express, 1× IDE/ATA 4× USB 1× VGA, Red, D845GVFT',
+		$this->assertArrayEquals(
+			["Motherboard Micro ATX Socket 478 (desktop mPGA478B)", "1× PCI, 3× PCI Express", "1× IDE/ATA, 4× USB, 1× VGA", "Red", "D845GVFT"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMotherboardNoModel() {
+	public function testMotherboardNoModel()
+	{
 		$item = new Item('B55');
 		$item
 			->addFeature(new Feature('type', 'motherboard'))
@@ -188,15 +197,16 @@ class MotherboardSummarizerTest extends TestCase {
 			->addFeature(new Feature('pcie-sockets-n', 3));
 
 		$summary = MotherboardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Motherboard Micro ATX Socket 478 (desktop mPGA478B), 1× PCI 3× PCI Express, 1× IDE/ATA 4× USB 1× VGA, Red, Compaq',
+		$this->assertArrayEquals(
+			["Motherboard Micro ATX Socket 478 (desktop mPGA478B)", "1× PCI, 3× PCI Express", "1× IDE/ATA, 4× USB, 1× VGA", "Red", "Compaq"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMotherboardNoCommercial() {
+	public function testMotherboardNoCommercial()
+	{
 		$item = new Item('B55');
 		$item
 			->addFeature(new Feature('type', 'motherboard'))
@@ -211,15 +221,16 @@ class MotherboardSummarizerTest extends TestCase {
 			->addFeature(new Feature('pcie-sockets-n', 3));
 
 		$summary = MotherboardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Motherboard Micro ATX Socket 478 (desktop mPGA478B), 1× PCI 3× PCI Express, 1× IDE/ATA 4× USB 1× VGA, Red',
+		$this->assertArrayEquals(
+			["Motherboard Micro ATX Socket 478 (desktop mPGA478B)", "1× PCI, 3× PCI Express", "1× IDE/ATA, 4× USB, 1× VGA", "Red"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMotherboardNoCommercialNoPortsNoColor() {
+	public function testMotherboardNoCommercialNoPortsNoColor()
+	{
 		$item = new Item('B55');
 		$item
 			->addFeature(new Feature('type', 'motherboard'))
@@ -230,15 +241,16 @@ class MotherboardSummarizerTest extends TestCase {
 			->addFeature(new Feature('pcie-sockets-n', 3));
 
 		$summary = MotherboardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Motherboard Micro ATX Socket 478 (desktop mPGA478B), 1× PCI 3× PCI Express',
+		$this->assertArrayEquals(
+			["Motherboard Micro ATX Socket 478 (desktop mPGA478B)", "1× PCI, 3× PCI Express"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMotherboardNoCommercialNoPortsNoColorNoPorts() {
+	public function testMotherboardNoCommercialNoPortsNoColorNoPorts()
+	{
 		$item = new Item('B55');
 		$item
 			->addFeature(new Feature('type', 'motherboard'))
@@ -246,30 +258,32 @@ class MotherboardSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = MotherboardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Motherboard Micro ATX',
+		$this->assertArrayEquals(
+			["Motherboard Micro ATX"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMotherboardNothing() {
+	public function testMotherboardNothing()
+	{
 		$item = new Item('B55');
 		$item
 			->addFeature(new Feature('type', 'motherboard'))
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = MotherboardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Motherboard',
+		$this->assertArrayEquals(
+			["Motherboard"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMotherboardIssue219() {
+	public function testMotherboardIssue219()
+	{
 		$item = new Item('B123');
 		$item
 			->addFeature(new Feature('type', 'motherboard'))
@@ -286,15 +300,16 @@ class MotherboardSummarizerTest extends TestCase {
 			->addFeature(new Feature('pcie-sockets-n', 3));
 
 		$summary = MotherboardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Motherboard Micro ATX Socket 370, 1× PCI 3× PCI Express, 1× IDE/ATA 4× USB 1× VGA, Red, Compaq F00B4R',
+		$this->assertArrayEquals(
+			["Motherboard Micro ATX Socket 370", "1× PCI, 3× PCI Express", "1× IDE/ATA, 4× USB, 1× VGA", "Red", "Compaq F00B4R"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testMotherboardIssue219SocketSocket() {
+	public function testMotherboardIssue219SocketSocket()
+	{
 		$item = new Item('B123');
 		$item
 			->addFeature(new Feature('type', 'motherboard'))
@@ -311,12 +326,11 @@ class MotherboardSummarizerTest extends TestCase {
 			->addFeature(new Feature('pcie-sockets-n', 3));
 
 		$summary = MotherboardSummarizer::summarize($item);
-		$this->assertEquals(
-			'Motherboard Micro ATX Socket 7, 1× PCI 3× PCI Express, 1× IDE/ATA 4× USB 1× VGA, Red, Compaq F00B4R',
+		$this->assertArrayEquals(
+			["Motherboard Micro ATX Socket 7", "1× PCI, 3× PCI Express", "1× IDE/ATA, 4× USB, 1× VGA", "Red", "Compaq F00B4R"],
 			$summary
 		);
 
 		return $summary;
 	}
-
 }

--- a/tests/SSRv1/Summary/OddSummarizerTest.php
+++ b/tests/SSRv1/Summary/OddSummarizerTest.php
@@ -1,15 +1,17 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
 use WEEEOpen\Tarallo\Feature;
 use WEEEOpen\Tarallo\Item;
 use WEEEOpen\Tarallo\SSRv1\Summary\OddSummarizer;
+use WEEEOpen\TaralloTest\SSRv1\Summary\SummarizerTestCase;
 
 /**
  * @covers \WEEEOpen\Tarallo\SSRv1\Summary\OddSummarizer
  */
-class OddSummarizerTest extends TestCase {
-	public function testOdd(){
+class OddSummarizerTest extends SummarizerTestCase
+{
+	public function testOdd()
+	{
 		$item = new Item('ODD200');
 		$item
 			->addFeature(new Feature('type', 'odd'))
@@ -22,15 +24,16 @@ class OddSummarizerTest extends TestCase {
 			->addFeature(new Feature('odd-form-factor', '5.25'));
 
 		$summary = OddSummarizer::summarize($item);
-		$this->assertEquals(
-			'ODD 5.25 in. DVD-RW, SATA, Light grey, Toshiba MK1234GSX',
+		$this->assertArrayEquals(
+			["ODD 5.25 in. DVD-RW", "SATA", "Light grey", "Toshiba MK1234GSX"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testOddNoOddType(){
+	public function testOddNoOddType()
+	{
 		$item = new Item('ODD200');
 		$item
 			->addFeature(new Feature('type', 'odd'))
@@ -42,15 +45,16 @@ class OddSummarizerTest extends TestCase {
 			->addFeature(new Feature('odd-form-factor', '5.25'));
 
 		$summary = OddSummarizer::summarize($item);
-		$this->assertEquals(
-			'ODD 5.25 in., SATA, Light grey, Toshiba MK1234GSX',
+		$this->assertArrayEquals(
+			["ODD 5.25 in.", "SATA", "Light grey", "Toshiba MK1234GSX"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testOddNoFormFactor(){
+	public function testOddNoFormFactor()
+	{
 		$item = new Item('ODD200');
 		$item
 			->addFeature(new Feature('type', 'odd'))
@@ -62,15 +66,16 @@ class OddSummarizerTest extends TestCase {
 			->addFeature(new Feature('sata-ports-n', 1));
 
 		$summary = OddSummarizer::summarize($item);
-		$this->assertEquals(
-			'ODD DVD-RW, SATA, Light grey, Toshiba MK1234GSX',
+		$this->assertArrayEquals(
+			["ODD DVD-RW", "SATA", "Light grey", "Toshiba MK1234GSX"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testOddNoFormFactorNoOddType(){
+	public function testOddNoFormFactorNoOddType()
+	{
 		$item = new Item('ODD200');
 		$item
 			->addFeature(new Feature('type', 'odd'))
@@ -81,15 +86,16 @@ class OddSummarizerTest extends TestCase {
 			->addFeature(new Feature('sata-ports-n', 1));
 
 		$summary = OddSummarizer::summarize($item);
-		$this->assertEquals(
-			'ODD, SATA, Light grey, Toshiba MK1234GSX',
+		$this->assertArrayEquals(
+			["ODD", "SATA", "Light grey", "Toshiba MK1234GSX"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testOddNoPorts(){
+	public function testOddNoPorts()
+	{
 		$item = new Item('ODD200');
 		$item
 			->addFeature(new Feature('type', 'odd'))
@@ -101,14 +107,14 @@ class OddSummarizerTest extends TestCase {
 			->addFeature(new Feature('odd-form-factor', '5.25'));
 
 		$summary = OddSummarizer::summarize($item);
-		$this->assertEquals(
-			'ODD 5.25 in. DVD-RW, Light grey, Toshiba MK1234GSX',
+		$this->assertArrayEquals(
+			["ODD 5.25 in. DVD-RW", "Light grey", "Toshiba MK1234GSX"],
 			$summary
 		);
-
 	}
 
-	public function testOddNoPortsNoCommercial() {
+	public function testOddNoPortsNoCommercial()
+	{
 		$item = new Item('ODD200');
 		$item
 			->addFeature(new Feature('type', 'odd'))
@@ -118,15 +124,16 @@ class OddSummarizerTest extends TestCase {
 			->addFeature(new Feature('odd-form-factor', '5.25'));
 
 		$summary = OddSummarizer::summarize($item);
-		$this->assertEquals(
-			'ODD 5.25 in. DVD-RW, Light grey',
+		$this->assertArrayEquals(
+			["ODD 5.25 in. DVD-RW", "Light grey"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testOddNoPortsNoCommercialNoColor() {
+	public function testOddNoPortsNoCommercialNoColor()
+	{
 		$item = new Item('ODD200');
 		$item
 			->addFeature(new Feature('type', 'odd'))
@@ -135,30 +142,32 @@ class OddSummarizerTest extends TestCase {
 			->addFeature(new Feature('odd-form-factor', '5.25'));
 
 		$summary = OddSummarizer::summarize($item);
-		$this->assertEquals(
-			'ODD 5.25 in. DVD-RW',
+		$this->assertArrayEquals(
+			["ODD 5.25 in. DVD-RW"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testOddNothing() {
+	public function testOddNothing()
+	{
 		$item = new Item('ODD200');
 		$item
 			->addFeature(new Feature('type', 'odd'))
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = OddSummarizer::summarize($item);
-		$this->assertEquals(
-			'ODD',
+		$this->assertArrayEquals(
+			["ODD"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testOddNoColor(){
+	public function testOddNoColor()
+	{
 		$item = new Item('ODD200');
 		$item
 			->addFeature(new Feature('type', 'odd'))
@@ -170,15 +179,16 @@ class OddSummarizerTest extends TestCase {
 			->addFeature(new Feature('odd-form-factor', '5.25'));
 
 		$summary = OddSummarizer::summarize($item);
-		$this->assertEquals(
-			'ODD 5.25 in. DVD-RW, SATA, Toshiba MK1234GSX',
+		$this->assertArrayEquals(
+			["ODD 5.25 in. DVD-RW", "SATA", "Toshiba MK1234GSX"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testOddNoColorNoCommercial(){
+	public function testOddNoColorNoCommercial()
+	{
 		$item = new Item('ODD200');
 		$item
 			->addFeature(new Feature('type', 'odd'))
@@ -188,15 +198,16 @@ class OddSummarizerTest extends TestCase {
 			->addFeature(new Feature('odd-form-factor', '5.25'));
 
 		$summary = OddSummarizer::summarize($item);
-		$this->assertEquals(
-			'ODD 5.25 in. DVD-RW, SATA',
+		$this->assertArrayEquals(
+			["ODD 5.25 in. DVD-RW", "SATA"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testOddNoBrand(){
+	public function testOddNoBrand()
+	{
 		$item = new Item('ODD200');
 		$item
 			->addFeature(new Feature('type', 'odd'))
@@ -208,15 +219,16 @@ class OddSummarizerTest extends TestCase {
 			->addFeature(new Feature('odd-form-factor', '5.25'));
 
 		$summary = OddSummarizer::summarize($item);
-		$this->assertEquals(
-			'ODD 5.25 in. DVD-RW, SATA, Light grey, MK1234GSX',
+		$this->assertArrayEquals(
+			["ODD 5.25 in. DVD-RW", "SATA", "Light grey", "MK1234GSX"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testOddNoCommercial(){
+	public function testOddNoCommercial()
+	{
 		$item = new Item('ODD200');
 		$item
 			->addFeature(new Feature('type', 'odd'))
@@ -227,15 +239,16 @@ class OddSummarizerTest extends TestCase {
 			->addFeature(new Feature('odd-form-factor', '5.25'));
 
 		$summary = OddSummarizer::summarize($item);
-		$this->assertEquals(
-			'ODD 5.25 in. DVD-RW, SATA, Light grey',
+		$this->assertArrayEquals(
+			["ODD 5.25 in. DVD-RW", "SATA", "Light grey"],
 			$summary
 		);
 
 		return $summary;
 	}
 
-	public function testOddNoModel(){
+	public function testOddNoModel()
+	{
 		$item = new Item('ODD200');
 		$item
 			->addFeature(new Feature('type', 'odd'))
@@ -247,8 +260,8 @@ class OddSummarizerTest extends TestCase {
 			->addFeature(new Feature('odd-form-factor', '5.25'));
 
 		$summary = OddSummarizer::summarize($item);
-		$this->assertEquals(
-			'ODD 5.25 in. DVD-RW, SATA, Light grey, Toshiba',
+		$this->assertArrayEquals(
+			["ODD 5.25 in. DVD-RW", "SATA", "Light grey", "Toshiba"],
 			$summary
 		);
 

--- a/tests/SSRv1/Summary/PsuSummarizerTest.php
+++ b/tests/SSRv1/Summary/PsuSummarizerTest.php
@@ -1,15 +1,17 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
 use WEEEOpen\Tarallo\Feature;
 use WEEEOpen\Tarallo\Item;
 use WEEEOpen\Tarallo\SSRv1\Summary\PsuSummarizer;
+use WEEEOpen\TaralloTest\SSRv1\Summary\SummarizerTestCase;
 
 /**
  * @covers \WEEEOpen\Tarallo\SSRv1\Summary\PsuSummarizer
  */
-class PsuSummarizerTest extends TestCase {
-	public function testPsu() {
+class PsuSummarizerTest extends SummarizerTestCase
+{
+	public function testPsu()
+	{
 		$item = new Item('A99');
 		$item
 			->addFeature(new Feature('brand', 'Corsair'))
@@ -26,13 +28,14 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU ATX 500 W (C13/C14, ATX 24 pin Mobo, 8 pin CPU, 14× PCI Express power pins, 4× SATA power), Black, Corsair CX500W',
+		$this->assertArrayEquals(
+			["PSU ATX 500 W", "C13/C14, ATX 24 pin Mobo, 8 pin CPU, 14× PCI Express power pins, 4× SATA power", "Black", "Corsair CX500W"],
 			$summary
 		);
 	}
-	
-	public function testPsuNoColor() {
+
+	public function testPsuNoColor()
+	{
 		$item = new Item('A99');
 		$item
 			->addFeature(new Feature('brand', 'Corsair'))
@@ -48,12 +51,14 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU ATX 500 W (C13/C14, ATX 24 pin Mobo, 8 pin CPU, 14× PCI Express power pins, 4× SATA power), Corsair CX500W',
+		$this->assertArrayEquals(
+			["PSU ATX 500 W", "C13/C14, ATX 24 pin Mobo, 8 pin CPU, 14× PCI Express power pins, 4× SATA power", "Corsair CX500W"],
 			$summary
 		);
 	}
-	public function testPsuNoBrand() {
+
+	public function testPsuNoBrand()
+	{
 		$item = new Item('A99');
 		$item
 			->addFeature(new Feature('model', 'CX500W'))
@@ -69,12 +74,14 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU ATX 500 W (C13/C14, ATX 24 pin Mobo, 8 pin CPU, 14× PCI Express power pins, 4× SATA power), Black, CX500W',
+		$this->assertArrayEquals(
+			["PSU ATX 500 W", "C13/C14, ATX 24 pin Mobo, 8 pin CPU, 14× PCI Express power pins, 4× SATA power", "Black", "CX500W"],
 			$summary
 		);
 	}
-	public function testPsuNoModel() {
+
+	public function testPsuNoModel()
+	{
 		$item = new Item('A99');
 		$item
 			->addFeature(new Feature('brand', 'Corsair'))
@@ -90,12 +97,14 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU ATX 500 W (C13/C14, ATX 24 pin Mobo, 8 pin CPU, 14× PCI Express power pins, 4× SATA power), Black, Corsair',
+		$this->assertArrayEquals(
+			["PSU ATX 500 W", "C13/C14, ATX 24 pin Mobo, 8 pin CPU, 14× PCI Express power pins, 4× SATA power", "Black", "Corsair"],
 			$summary
 		);
 	}
-	public function testPsuNoCommercial() {
+
+	public function testPsuNoCommercial()
+	{
 		$item = new Item('A99');
 		$item
 			->addFeature(new Feature('color', 'black'))
@@ -110,12 +119,14 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU ATX 500 W (C13/C14, ATX 24 pin Mobo, 8 pin CPU, 14× PCI Express power pins, 4× SATA power), Black',
+		$this->assertArrayEquals(
+			["PSU ATX 500 W", "C13/C14, ATX 24 pin Mobo, 8 pin CPU, 14× PCI Express power pins, 4× SATA power", "Black"],
 			$summary
 		);
 	}
-	public function testPsuNoCommercialNoColor() {
+
+	public function testPsuNoCommercialNoColor()
+	{
 		$item = new Item('A99');
 		$item
 			->addFeature(new Feature('pcie-power-pin-n', 14))
@@ -129,13 +140,14 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU ATX 500 W (C13/C14, ATX 24 pin Mobo, 8 pin CPU, 14× PCI Express power pins, 4× SATA power)',
+		$this->assertArrayEquals(
+			["PSU ATX 500 W", "C13/C14, ATX 24 pin Mobo, 8 pin CPU, 14× PCI Express power pins, 4× SATA power"],
 			$summary
 		);
 	}
-	
-	public function testPsuNoConnectors() {
+
+	public function testPsuNoConnectors()
+	{
 		$item = new Item('A99');
 		$item
 			->addFeature(new Feature('brand', 'Corsair'))
@@ -147,13 +159,14 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU ATX 500 W, Black, Corsair CX500W',
+		$this->assertArrayEquals(
+			["PSU ATX 500 W", "Black", "Corsair CX500W"],
 			$summary
 		);
 	}
-	
-	public function testPsuNoExternal() {
+
+	public function testPsuNoExternal()
+	{
 		$item = new Item('A99');
 		$item
 			->addFeature(new Feature('brand', 'Corsair'))
@@ -169,13 +182,14 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU ATX 500 W (ATX 24 pin Mobo, 8 pin CPU, 14× PCI Express power pins, 4× SATA power), Black, Corsair CX500W',
+		$this->assertArrayEquals(
+			["PSU ATX 500 W", "ATX 24 pin Mobo, 8 pin CPU, 14× PCI Express power pins, 4× SATA power", "Black", "Corsair CX500W"],
 			$summary
 		);
 	}
-	
-	public function testPsuNoInternal() {
+
+	public function testPsuNoInternal()
+	{
 		$item = new Item('A99');
 		$item
 			->addFeature(new Feature('brand', 'Corsair'))
@@ -188,13 +202,14 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU ATX 500 W (C13/C14), Black, Corsair CX500W',
+		$this->assertArrayEquals(
+			["PSU ATX 500 W", "C13/C14", "Black", "Corsair CX500W"],
 			$summary
 		);
 	}
-	
-	public function testPsuMoboOnly() {
+
+	public function testPsuMoboOnly()
+	{
 		$item = new Item('A99');
 		$item
 			->addFeature(new Feature('brand', 'Corsair'))
@@ -207,13 +222,14 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU ATX 500 W (ATX 24 pin Mobo), Black, Corsair CX500W',
+		$this->assertArrayEquals(
+			["PSU ATX 500 W", "ATX 24 pin Mobo", "Black", "Corsair CX500W"],
 			$summary
 		);
 	}
-	
-	public function testPsuNoWatt() {
+
+	public function testPsuNoWatt()
+	{
 		$item = new Item('A99');
 		$item
 			->addFeature(new Feature('brand', 'Corsair'))
@@ -229,13 +245,14 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU ATX (C13/C14, ATX 24 pin Mobo, 8 pin CPU, 14× PCI Express power pins, 4× SATA power), Black, Corsair CX500W',
+		$this->assertArrayEquals(
+			["PSU ATX", "C13/C14, ATX 24 pin Mobo, 8 pin CPU, 14× PCI Express power pins, 4× SATA power", "Black", "Corsair CX500W"],
 			$summary
 		);
 	}
-	
-	public function testPsuNoFF() {
+
+	public function testPsuNoFF()
+	{
 		$item = new Item('A99');
 		$item
 			->addFeature(new Feature('brand', 'Corsair'))
@@ -251,13 +268,14 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU 500 W (C13/C14, ATX 24 pin Mobo, 8 pin CPU, 14× PCI Express power pins, 4× SATA power), Black, Corsair CX500W',
+		$this->assertArrayEquals(
+			["PSU 500 W", "C13/C14, ATX 24 pin Mobo, 8 pin CPU, 14× PCI Express power pins, 4× SATA power", "Black", "Corsair CX500W"],
 			$summary
 		);
 	}
 
-	public function testPsuNoFFNoWattNoCommercial() {
+	public function testPsuNoFFNoWattNoCommercial()
+	{
 		$item = new Item('A99');
 		$item
 			->addFeature(new Feature('pcie-power-pin-n', 14))
@@ -269,13 +287,14 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU (C13/C14, ATX 24 pin Mobo, 8 pin CPU, 14× PCI Express power pins, 4× SATA power)',
+		$this->assertArrayEquals(
+			["PSU", "C13/C14, ATX 24 pin Mobo, 8 pin CPU, 14× PCI Express power pins, 4× SATA power"],
 			$summary
 		);
 	}
 
-	public function testPsuNoWattNoFFNoPorts() {
+	public function testPsuNoWattNoFFNoPorts()
+	{
 		$item = new Item('A99');
 		$item
 			->addFeature(new Feature('brand', 'Corsair'))
@@ -285,12 +304,14 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU, Black, Corsair CX500W',
+		$this->assertArrayEquals(
+			["PSU", "Black", "Corsair CX500W"],
 			$summary
 		);
 	}
-	public function testPsuNoWattNoFFNoPortsNoColor() {
+
+	public function testPsuNoWattNoFFNoPortsNoColor()
+	{
 		$item = new Item('A99');
 		$item
 			->addFeature(new Feature('brand', 'Corsair'))
@@ -299,12 +320,14 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU, Corsair CX500W',
+		$this->assertArrayEquals(
+			["PSU", "Corsair CX500W"],
 			$summary
 		);
 	}
-	public function testPsuNoWattNoFFNoPortsNoCommercial() {
+
+	public function testPsuNoWattNoFFNoPortsNoCommercial()
+	{
 		$item = new Item('A99');
 		$item
 			->addFeature(new Feature('color', 'black'))
@@ -312,25 +335,28 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU, Black',
+		$this->assertArrayEquals(
+			["PSU", "Black"],
 			$summary
 		);
 	}
-	public function testPsuNothing() {
+
+	public function testPsuNothing()
+	{
 		$item = new Item('A99');
 		$item
 			->addFeature(new Feature('type', 'psu'))
 			->addFeature(new Feature('working', 'no'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU',
+		$this->assertArrayEquals(
+			["PSU"],
 			$summary
 		);
 	}
 
-	public function testPsuManufacturer() {
+	public function testPsuManufacturer()
+	{
 		$item = new Item('A420');
 		$item
 			->addFeature(new Feature('brand', 'HP'))
@@ -347,13 +373,14 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU Proprietary 100 W (C13/C14, ATX 24 pin Mobo, 8 pin CPU, 99× SATA power), Green, HP (Delta Eletronics) DPS-100DB A',
+		$this->assertArrayEquals(
+			["PSU Proprietary 100 W", "C13/C14, ATX 24 pin Mobo, 8 pin CPU, 99× SATA power", "Green", "HP (Delta Eletronics) DPS-100DB A"],
 			$summary
 		);
 	}
 
-	public function testPsuManufacturerAndInternalName() {
+	public function testPsuManufacturerAndInternalName()
+	{
 		$item = new Item('A420');
 		$item
 			->addFeature(new Feature('brand', 'HP'))
@@ -371,13 +398,14 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU Proprietary 100 W (C13/C14, ATX 24 pin Mobo, 8 pin CPU, 99× SATA power), Green, HP DPS-100DB A (Delta Eletronics F00B4R)',
+		$this->assertArrayEquals(
+			["PSU Proprietary 100 W", "C13/C14, ATX 24 pin Mobo, 8 pin CPU, 99× SATA power", "Green", "HP DPS-100DB A (Delta Eletronics F00B4R)"],
 			$summary
 		);
 	}
 
-	public function testPsuInternalName() {
+	public function testPsuInternalName()
+	{
 		$item = new Item('A420');
 		$item
 			->addFeature(new Feature('brand', 'HP'))
@@ -394,13 +422,14 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU Proprietary 100 W (C13/C14, ATX 24 pin Mobo, 8 pin CPU, 99× SATA power), Green, HP DPS-100DB A (F00B4R)',
+		$this->assertArrayEquals(
+			["PSU Proprietary 100 W", "C13/C14, ATX 24 pin Mobo, 8 pin CPU, 99× SATA power", "Green", "HP DPS-100DB A (F00B4R)"],
 			$summary
 		);
 	}
 
-	public function testPsuManufacturerAndInternalNameNoModel() {
+	public function testPsuManufacturerAndInternalNameNoModel()
+	{
 		$item = new Item('A420');
 		$item
 			->addFeature(new Feature('brand', 'HP'))
@@ -417,13 +446,14 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU Proprietary 100 W (C13/C14, ATX 24 pin Mobo, 8 pin CPU, 99× SATA power), Green, HP (Delta Eletronics F00B4R)',
+		$this->assertArrayEquals(
+			["PSU Proprietary 100 W", "C13/C14, ATX 24 pin Mobo, 8 pin CPU, 99× SATA power", "Green", "HP (Delta Eletronics F00B4R)"],
 			$summary
 		);
 	}
 
-	public function testPsuManufacturerAndInternalNameNoBrand() {
+	public function testPsuManufacturerAndInternalNameNoBrand()
+	{
 		$item = new Item('A420');
 		$item
 			->addFeature(new Feature('brand-manufacturer', 'Delta Eletronics'))
@@ -440,13 +470,14 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU Proprietary 100 W (C13/C14, ATX 24 pin Mobo, 8 pin CPU, 99× SATA power), Green, DPS-100DB A (Delta Eletronics F00B4R)',
+		$this->assertArrayEquals(
+			["PSU Proprietary 100 W", "C13/C14, ATX 24 pin Mobo, 8 pin CPU, 99× SATA power", "Green", "DPS-100DB A (Delta Eletronics F00B4R)"],
 			$summary
 		);
 	}
 
-	public function testPsuManufacturerAndInternalNameNoBrandNoModel() {
+	public function testPsuManufacturerAndInternalNameNoBrandNoModel()
+	{
 		$item = new Item('A420');
 		$item
 			->addFeature(new Feature('brand-manufacturer', 'Delta Eletronics'))
@@ -462,8 +493,8 @@ class PsuSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = PsuSummarizer::summarize($item);
-		$this->assertEquals(
-			'PSU Proprietary 100 W (C13/C14, ATX 24 pin Mobo, 8 pin CPU, 99× SATA power), Green, (Delta Eletronics F00B4R)',
+		$this->assertArrayEquals(
+			["PSU Proprietary 100 W", "C13/C14, ATX 24 pin Mobo, 8 pin CPU, 99× SATA power", "Green", "(Delta Eletronics F00B4R)"],
 			$summary
 		);
 	}

--- a/tests/SSRv1/Summary/RamSummarizerTest.php
+++ b/tests/SSRv1/Summary/RamSummarizerTest.php
@@ -1,15 +1,17 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
 use WEEEOpen\Tarallo\Feature;
 use WEEEOpen\Tarallo\Item;
 use WEEEOpen\Tarallo\SSRv1\Summary\RamSummarizer;
+use WEEEOpen\TaralloTest\SSRv1\Summary\SummarizerTestCase;
 
 /**
  * @covers \WEEEOpen\Tarallo\SSRv1\Summary\RamSummarizer
  */
-class RamSummarizerTest extends TestCase {
-	public function testRam() {
+class RamSummarizerTest extends SummarizerTestCase
+{
+	public function testRam()
+	{
 		$item = new Item('R123');
 		$item->addFeature(new Feature('brand', 'Kingston'))
 			->addFeature(new Feature('capacity-byte', 2147483648))
@@ -25,22 +27,24 @@ class RamSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = RamSummarizer::summarize($item);
-		$this->assertEquals('RAM DDR3 SODIMM 2 GiB 1.066 GHz, Kingston ACR256X64D3S13C9G', $summary);
+		$this->assertArrayEquals(["RAM DDR3 SODIMM 2 GiB 1.066 GHz", "Kingston ACR256X64D3S13C9G"], $summary);
 
 		return $summary;
 	}
 
-	public function testRamNothing() {
+	public function testRamNothing()
+	{
 		$item = new Item('R123');
 		$item->addFeature(new Feature('type', 'ram'));
 
 		$summary = RamSummarizer::summarize($item);
-		$this->assertEquals('RAM', $summary);
+		$this->assertArrayEquals(["RAM"], $summary);
 
 		return $summary;
 	}
 
-	public function testRamMissingFreq() {
+	public function testRamMissingFreq()
+	{
 		$item = new Item('R123');
 		$item->addFeature(new Feature('brand', 'Kingston'))
 			->addFeature(new Feature('capacity-byte', 2147483648))
@@ -55,12 +59,13 @@ class RamSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = RamSummarizer::summarize($item);
-		$this->assertEquals('RAM DDR3 SODIMM 2 GiB, Kingston ACR256X64D3S13C9G', $summary);
+		$this->assertArrayEquals(["RAM DDR3 SODIMM 2 GiB", "Kingston ACR256X64D3S13C9G"], $summary);
 
 		return $summary;
 	}
 
-	public function testRamMissingSize() {
+	public function testRamMissingSize()
+	{
 		$item = new Item('R123');
 		$item->addFeature(new Feature('brand', 'Kingston'))
 			->addFeature(new Feature('color', 'green'))
@@ -75,12 +80,13 @@ class RamSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = RamSummarizer::summarize($item);
-		$this->assertEquals('RAM DDR3 SODIMM 1.066 GHz, Kingston ACR256X64D3S13C9G', $summary);
+		$this->assertArrayEquals(["RAM DDR3 SODIMM 1.066 GHz", "Kingston ACR256X64D3S13C9G"], $summary);
 
 		return $summary;
 	}
 
-	public function testRamMissingSizeAndFreq() {
+	public function testRamMissingSizeAndFreq()
+	{
 		$item = new Item('R123');
 		$item->addFeature(new Feature('brand', 'Kingston'))
 			->addFeature(new Feature('color', 'green'))
@@ -94,12 +100,13 @@ class RamSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = RamSummarizer::summarize($item);
-		$this->assertEquals('RAM DDR3 SODIMM, Kingston ACR256X64D3S13C9G', $summary);
+		$this->assertArrayEquals(["RAM DDR3 SODIMM", "Kingston ACR256X64D3S13C9G"], $summary);
 
 		return $summary;
 	}
 
-	public function testRamMissingType() {
+	public function testRamMissingType()
+	{
 		$item = new Item('R123');
 		$item->addFeature(new Feature('brand', 'Kingston'))
 			->addFeature(new Feature('capacity-byte', 2147483648))
@@ -114,12 +121,13 @@ class RamSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = RamSummarizer::summarize($item);
-		$this->assertEquals('RAM SODIMM 2 GiB 1.066 GHz, Kingston ACR256X64D3S13C9G', $summary);
+		$this->assertArrayEquals(["RAM SODIMM 2 GiB 1.066 GHz", "Kingston ACR256X64D3S13C9G"], $summary);
 
 		return $summary;
 	}
 
-	public function testRamMissingFormFactor() {
+	public function testRamMissingFormFactor()
+	{
 		$item = new Item('R123');
 		$item->addFeature(new Feature('brand', 'Kingston'))
 			->addFeature(new Feature('capacity-byte', 2147483648))
@@ -134,24 +142,26 @@ class RamSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = RamSummarizer::summarize($item);
-		$this->assertEquals('RAM DDR3 2 GiB 1.066 GHz, Kingston ACR256X64D3S13C9G', $summary);
+		$this->assertArrayEquals(["RAM DDR3 2 GiB 1.066 GHz", "Kingston ACR256X64D3S13C9G"], $summary);
 
 		return $summary;
 	}
 
-	public function testRamMissingLotsOfStuff() {
+	public function testRamMissingLotsOfStuff()
+	{
 		$item = new Item('R123');
 		$item->addFeature(new Feature('brand', 'Kingston'))
 			->addFeature(new Feature('model', 'ACR256X64D3S13C9G'))
 			->addFeature(new Feature('type', 'ram'));
 
 		$summary = RamSummarizer::summarize($item);
-		$this->assertEquals('RAM, Kingston ACR256X64D3S13C9G', $summary);
+		$this->assertArrayEquals(["RAM", "Kingston ACR256X64D3S13C9G"], $summary);
 
 		return $summary;
 	}
 
-	public function testRamMissingModel() {
+	public function testRamMissingModel()
+	{
 		$item = new Item('R123');
 		$item->addFeature(new Feature('brand', 'Kingston'))
 			->addFeature(new Feature('capacity-byte', 2147483648))
@@ -166,12 +176,13 @@ class RamSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = RamSummarizer::summarize($item);
-		$this->assertEquals('RAM DDR3 SODIMM 2 GiB 1.066 GHz, Kingston', $summary);
+		$this->assertArrayEquals(["RAM DDR3 SODIMM 2 GiB 1.066 GHz", "Kingston"], $summary);
 
 		return $summary;
 	}
 
-	public function testRamMissingBrand() {
+	public function testRamMissingBrand()
+	{
 		$item = new Item('R123');
 		$item->addFeature(new Feature('capacity-byte', 2147483648))
 			->addFeature(new Feature('color', 'green'))
@@ -186,12 +197,13 @@ class RamSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = RamSummarizer::summarize($item);
-		$this->assertEquals('RAM DDR3 SODIMM 2 GiB 1.066 GHz, ACR256X64D3S13C9G', $summary);
+		$this->assertArrayEquals(["RAM DDR3 SODIMM 2 GiB 1.066 GHz", "ACR256X64D3S13C9G"], $summary);
 
 		return $summary;
 	}
 
-	public function testRamMissingBrandAndModel() {
+	public function testRamMissingBrandAndModel()
+	{
 		$item = new Item('R123');
 		$item->addFeature(new Feature('capacity-byte', 2147483648))
 			->addFeature(new Feature('color', 'green'))
@@ -205,12 +217,13 @@ class RamSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = RamSummarizer::summarize($item);
-		$this->assertEquals('RAM DDR3 SODIMM 2 GiB 1.066 GHz', $summary);
+		$this->assertArrayEquals(["RAM DDR3 SODIMM 2 GiB 1.066 GHz"], $summary);
 
 		return $summary;
 	}
 
-	public function testRamEcc() {
+	public function testRamEcc()
+	{
 		$item = new Item('R123');
 		$item->addFeature(new Feature('brand', 'Kingston'))
 			->addFeature(new Feature('capacity-byte', 2147483648))
@@ -226,12 +239,13 @@ class RamSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = RamSummarizer::summarize($item);
-		$this->assertEquals('RAM ECC DDR3 SODIMM 2 GiB 1.066 GHz, Kingston ACR256X64D3S13C9G', $summary);
+		$this->assertArrayEquals(["RAM ECC DDR3 SODIMM 2 GiB 1.066 GHz", "Kingston ACR256X64D3S13C9G"], $summary);
 
 		return $summary;
 	}
 
-	public function testRamNoEcc() {
+	public function testRamNoEcc()
+	{
 		$item = new Item('R123');
 		$item->addFeature(new Feature('brand', 'Kingston'))
 			->addFeature(new Feature('capacity-byte', 2147483648))
@@ -246,12 +260,13 @@ class RamSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = RamSummarizer::summarize($item);
-		$this->assertEquals('RAM (ECC?) DDR3 SODIMM 2 GiB 1.066 GHz, Kingston ACR256X64D3S13C9G', $summary);
+		$this->assertArrayEquals(["RAM (ECC?) DDR3 SODIMM 2 GiB 1.066 GHz", "Kingston ACR256X64D3S13C9G"], $summary);
 
 		return $summary;
 	}
 
-	public function testRamEccMissingType() {
+	public function testRamEccMissingType()
+	{
 		$item = new Item('R123');
 		$item->addFeature(new Feature('brand', 'Kingston'))
 			->addFeature(new Feature('capacity-byte', 2147483648))
@@ -266,12 +281,13 @@ class RamSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = RamSummarizer::summarize($item);
-		$this->assertEquals('RAM ECC SODIMM 2 GiB 1.066 GHz, Kingston ACR256X64D3S13C9G', $summary);
+		$this->assertArrayEquals(["RAM ECC SODIMM 2 GiB 1.066 GHz", "Kingston ACR256X64D3S13C9G"], $summary);
 
 		return $summary;
 	}
 
-	public function testRamEccMissingStuff() {
+	public function testRamEccMissingStuff()
+	{
 		$item = new Item('R123');
 		$item->addFeature(new Feature('brand', 'Kingston'))
 			->addFeature(new Feature('capacity-byte', 2147483648))
@@ -285,12 +301,13 @@ class RamSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = RamSummarizer::summarize($item);
-		$this->assertEquals('RAM ECC 2 GiB 1.066 GHz, Kingston ACR256X64D3S13C9G', $summary);
+		$this->assertArrayEquals(["RAM ECC 2 GiB 1.066 GHz", "Kingston ACR256X64D3S13C9G"], $summary);
 
 		return $summary;
 	}
 
-	public function testRamEccMissingFirstPart() {
+	public function testRamEccMissingFirstPart()
+	{
 		$item = new Item('R123');
 		$item->addFeature(new Feature('brand', 'Kingston'))
 			->addFeature(new Feature('model', 'ACR256X64D3S13C9G'))
@@ -298,23 +315,25 @@ class RamSummarizerTest extends TestCase {
 			->addFeature(new Feature('type', 'ram'));
 
 		$summary = RamSummarizer::summarize($item);
-		$this->assertEquals('RAM ECC, Kingston ACR256X64D3S13C9G', $summary);
+		$this->assertArrayEquals(["RAM ECC", "Kingston ACR256X64D3S13C9G"], $summary);
 
 		return $summary;
 	}
 
-	public function testRamEccMissingEverything() {
+	public function testRamEccMissingEverything()
+	{
 		$item = new Item('R123');
 		$item->addFeature(new Feature('ram-ecc', 'yes'))
 			->addFeature(new Feature('type', 'ram'));
 
 		$summary = RamSummarizer::summarize($item);
-		$this->assertEquals('RAM ECC', $summary);
+		$this->assertArrayEquals(["RAM ECC"], $summary);
 
 		return $summary;
 	}
 
-	public function testRamSimm() {
+	public function testRamSimm()
+	{
 		$item = new Item('R123');
 		$item
 			->addFeature(new Feature('brand', 'PTC'))
@@ -327,7 +346,7 @@ class RamSummarizerTest extends TestCase {
 			->addFeature(new Feature('type', 'ram'));
 
 		$summary = RamSummarizer::summarize($item);
-		$this->assertEquals('RAM SIMM 8 MiB, PTC M1V-0 9638', $summary);
+		$this->assertArrayEquals(["RAM SIMM 8 MiB", "PTC M1V-0 9638"], $summary);
 
 		return $summary;
 	}

--- a/tests/SSRv1/Summary/SimpleDeviceSummarizerTest.php
+++ b/tests/SSRv1/Summary/SimpleDeviceSummarizerTest.php
@@ -1,15 +1,17 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
 use WEEEOpen\Tarallo\Feature;
 use WEEEOpen\Tarallo\Item;
 use WEEEOpen\Tarallo\SSRv1\Summary\SimpleDeviceSummarizer;
+use WEEEOpen\TaralloTest\SSRv1\Summary\SummarizerTestCase;
 
 /**
  * @covers \WEEEOpen\Tarallo\SSRv1\Summary\SimpleDeviceSummarizer
  */
-class SimpleDeviceSummarizerTest extends TestCase {
-	public function testStorageCard() {
+class SimpleDeviceSummarizerTest extends SummarizerTestCase
+{
+	public function testStorageCard()
+	{
 		$item = new Item('Q1');
 		$item
 			->addFeature(new Feature('color', 'green'))
@@ -25,8 +27,8 @@ class SimpleDeviceSummarizerTest extends TestCase {
 			->addFeature(new Feature('working', 'yes'));
 
 		$summary = SimpleDeviceSummarizer::summarize($item);
-		$this->assertEquals(
-			'Storage card, 1× SAS (SATA connector), Green, Outtel SRC123567',
+		$this->assertArrayEquals(
+			["Storage card", "1× SAS (SATA connector)", "Green", "Outtel SRC123567"],
 			$summary
 		);
 

--- a/tests/SSRv1/Summary/SummarizerTestCase.php
+++ b/tests/SSRv1/Summary/SummarizerTestCase.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace WEEEOpen\TaralloTest\SSRv1\Summary;
+
+use PHPUnit\Framework\TestCase;
+
+class SummarizerTestCase extends TestCase
+{
+	final public function assertArrayEquals(array $expected, array $actual): void
+	{
+		$this->assertTrue(array_values($expected) === array_values($actual), print_r($expected, true) . "!=\n" . print_r($actual, true) . "diff=\n" . print_r(array_diff($expected, $actual), true));
+	}
+}


### PR DESCRIPTION
Let's give this another try. Fixing the tests took more time than changing the output format of `Summarizer`, but thankfully some regex and `sed` helped :sweat_smile:

Tests pass and I can't spot any issue with any of the summaries. The one intentional change to the summary output is that ports are always split by ` ,` on everything. Can revert that if you think it doesn't look good that way.

The key of the returned array can be used for extra context if you ever want extra context

![image](https://user-images.githubusercontent.com/490500/204054382-9c908dfe-7154-4134-8147-80e3c3409929.png)
