### PR TITLE
Fix icon for items with no type set

### DIFF
--- a/src/SSRv1/templates/item.php
+++ b/src/SSRv1/templates/item.php
@@ -73,7 +73,7 @@ endif; ?>
 <article class="container item<?=$recursion ? '' : ' root'?><?=$working?><?=$editing && $target ? ' head editing' : ''?><?= $deletedAt === null ? '' : ' deleted' ?>"
 		data-code="<?=$code_escaped?>">
 	<header class="row align-items-center">
-		<?php $this->insert('productIcon', ['type' => $features['type']->value]) ?>
+		<?php $this->insert('productIcon', ['type' => $features['type']->value ?? null]) ?>
 		<h4 class="p-2 col m-0" id="code-<?=$code_escaped?>"><?=$code_escaped?></h4>
 		<nav class="p-2 m-0 ml-auto itembuttons inheader">
 			<?php if ($editing) : ?>


### PR DESCRIPTION
Noticed this on item R6969 in the example dataset. Accessing a property of `null` is a warning

**Before:**
![before](https://user-images.githubusercontent.com/490500/236317875-64f3d859-4cde-4f67-a8f3-bbfc51117746.png)

**After:**
![after](https://user-images.githubusercontent.com/490500/236317651-9e7757f0-28c2-4be2-b1f2-e2495ddc7cfb.png)
